### PR TITLE
Add workflow to use GCP KMS keys for signing snapshot and timestamp metadata 

### DIFF
--- a/.github/workflows/snapshot-timestamp.yml
+++ b/.github/workflows/snapshot-timestamp.yml
@@ -1,0 +1,87 @@
+name: Snapshot and Timestamp
+
+# Execute this as a biweekly cron job and on changes to repository/ 
+# when new published metadata is submitted.
+on:
+  # Enable cron when repository published with these keys. 
+  # schedule:
+  #   cron: '0 0 */14 * *' # every 14 days
+  workflow_dispatch:
+
+jobs:  
+  snapshot_and_timestamp:
+    runs-on: ubuntu-20.04
+    permissions:
+      id-token: 'write'
+    steps:
+      - uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
+      - name: setup
+        run: |
+          echo "REPO=$(pwd)/repository/" >> $GITHUB_ENV
+          echo "SNAPSHOT_KEY=gcpkms://projects/project-rekor/locations/global/keyRings/sigstore-root/cryptoKeys/snapshot" >> $GITHUB_ENV
+          echo "TIMESTAMP_KEY=gcpkms://projects/project-rekor/locations/global/keyRings/sigstore-root/cryptoKeys/timestamp" >> $GITHUB_ENV
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.17.x
+      - uses: 'google-github-actions/setup-gcloud@v0.2.1'
+        with:
+          project_id: project-rekor
+      # Setup OIDC->SA auth
+      - uses: 'google-github-actions/auth@v0.3.0'
+        id: auth
+        with:
+          token_format: 'access_token'
+          workload_identity_provider: 'projects/237800849078/locations/global/workloadIdentityPools/root-signing-pool/providers/sigstore-root'
+          service_account: 'sigstore-root-signing@project-rekor.iam.gserviceaccount.com'
+          create_credentials_file: true
+      - name: Login
+        run: |
+          gcloud auth login --brief --cred-file="${{ steps.auth.outputs.credentials_file_path }}"
+          gcloud auth list
+
+      # Snapshot and timestamp    
+      - name: build
+        run: |
+          sudo apt-get install libpcsclite-dev
+          go build -o tuf -tags=pivkey ./cmd/tuf/
+      - name: snapshot
+        run: |
+          ./tuf snapshot -repository $REPO
+          ./tuf sign -repository $REPO -roles snapshot -key ${SNAPSHOT_KEY}
+          ./tuf timestamp -repository $REPO
+          ./tuf sign -repository $REPO -roles timestamp -key ${TIMESTAMP_KEY}
+      - name: publish
+        run: |
+          ./tuf publish -repository $REPO
+          ls $REPO/repository/
+      - name: Upload snapshot and timestamp
+        uses: 'actions/upload-artifact@v2'
+        with:
+          name: snapshot-and-timestamp
+          path: repository/repository/
+          retention-days: 5
+
+
+  push:
+    needs: snapshot_and_timestamp
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
+      - uses: 'actions/download-artifact@v2'
+        with:
+          name: snapshot-and-timestamp
+          path: repository/repository/
+      # Open pull request changes
+      - name: create pull request
+        uses: 'peter-evans/create-pull-request@v3'
+        with:
+          commit-message: update snapshot and timestamp
+          title: Update Snapshot and Timestamp
+          body: Sign snapshot and timestamp files
+          branch: update-snapshot-timestamp
+          signoff: true
+           

--- a/cmd/tuf/app/init.go
+++ b/cmd/tuf/app/init.go
@@ -148,6 +148,9 @@ func InitCmd(ctx context.Context, directory, previous string, targets targetsFla
 	if err := repo.AddTargetsWithExpires(relativePaths, nil, expiration); err != nil {
 		return fmt.Errorf("error adding targets %w", err)
 	}
+	if err := repo.SetThreshold("targets", threshold); err != nil {
+		return err
+	}
 
 	// Add blank signatures to root and targets
 	t, err := prepo.GetTargetsFromStore(store)

--- a/scripts/step-3.sh
+++ b/scripts/step-3.sh
@@ -32,7 +32,7 @@ git status
 
 # Timestamp and sign the timestamp with timestamp kms key
 ./tuf timestamp -repository $REPO
-./tuf sign -repository $REPO -roles timestamp -key ${TIMESTMAP_KEY}
+./tuf sign -repository $REPO -roles timestamp -key ${TIMESTAMP_KEY}
 
 git checkout -b sign-snapshot
 git add ceremony/


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

The run is currently manually triggered, and the cron part is commented out. I will uncomment once we re-sign the root metadata to move over to these keys.

The run uses GCP KMS keys set in environment variables to sign over `$REPO` and then create a pull request with the update.

Signing these manifests will also validate that the generated metadata is valid, so we will never end up creating the pull request without valid data.
