### PR TITLE
Fix up ALL the bugs in root-signing v2!

### DIFF
--- a/cmd/tuf/app/init.go
+++ b/cmd/tuf/app/init.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
+	"github.com/pkg/errors"
 	pkeys "github.com/sigstore/root-signing/pkg/keys"
 	prepo "github.com/sigstore/root-signing/pkg/repo"
 	cjson "github.com/tent/canonical-json-go"
@@ -108,18 +109,30 @@ func InitCmd(ctx context.Context, directory, previous string, targets targetsFla
 				return err
 			}
 		}
-		if err := repo.SetThreshold("root", threshold); err != nil {
+		if err := repo.SetThreshold(role, threshold); err != nil {
 			return err
 		}
 	}
 
-	// Add online snapshot and timestamp keys with a shorter expiration.
+	// Revoke old root keys used for snapshot and timestamp.
+	for _, role := range []string{"snapshot", "timestamp"} {
+		for _, tufKey := range keys {
+			if err := repo.RevokeKey(role, tufKey.IDs()[0]); err != nil {
+				return errors.Wrap(err, "error revoking key")
+			}
+		}
+		if err := repo.SetThreshold(role, 1); err != nil {
+			return err
+		}
+	}
+	// Add online snapshot and timestamp keys with a shorter expiration of three weeks.
 	for role, keyRef := range map[string]string{"snapshot": snapshotRef, "timestamp": timestampRef} {
+		// Add new online keys
 		signerKey, err := pkeys.GetKmsSigningKey(ctx, keyRef)
 		if err != nil {
 			return err
 		}
-		if err := repo.AddVerificationKeyWithExpiration(role, signerKey.Key, time.Now().AddDate(0, 0, 14).UTC()); err != nil {
+		if err := repo.AddVerificationKeyWithExpiration(role, signerKey.Key, time.Now().AddDate(0, 0, 21).UTC()); err != nil {
 			return err
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/cenkalti/backoff/v3 v3.2.2 // indirect
 	github.com/mitchellh/mapstructure v1.4.2 // indirect
 	github.com/peterbourgon/ff/v3 v3.1.0
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/sigstore/cosign v1.1.0
 	github.com/sigstore/sigstore v0.0.0-20210729211320-56a91f560f44
 	github.com/tent/canonical-json-go v0.0.0-20130607151641-96e4ba3a7613
@@ -23,4 +24,4 @@ require (
 	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b
 )
 
-replace github.com/theupdateframework/go-tuf => github.com/asraa/go-tuf v0.0.0-20211008162054-6bdeb1d1d9ba
+replace github.com/theupdateframework/go-tuf => github.com/asraa/go-tuf v0.0.0-20211018154110-b7b6ddad25b5

--- a/go.sum
+++ b/go.sum
@@ -217,6 +217,10 @@ github.com/asraa/go-tuf v0.0.0-20211008150546-c069b270edc5 h1:sd+S5P4jCl5KNlkGkN
 github.com/asraa/go-tuf v0.0.0-20211008150546-c069b270edc5/go.mod h1:BeoQvv7b+dWjjIWXghwBzUPEY5FZZua52JVbC6/maiw=
 github.com/asraa/go-tuf v0.0.0-20211008162054-6bdeb1d1d9ba h1:MKnVvFnsRdDLO+cM94BIJd766c5xLZZ55Jgdzj1eAug=
 github.com/asraa/go-tuf v0.0.0-20211008162054-6bdeb1d1d9ba/go.mod h1:BeoQvv7b+dWjjIWXghwBzUPEY5FZZua52JVbC6/maiw=
+github.com/asraa/go-tuf v0.0.0-20211018143521-52829c8e1649 h1:/KxzEglcm5qF1h0saXE4Ks8y9+NIZLHBdHYsfVCpwuk=
+github.com/asraa/go-tuf v0.0.0-20211018143521-52829c8e1649/go.mod h1:BeoQvv7b+dWjjIWXghwBzUPEY5FZZua52JVbC6/maiw=
+github.com/asraa/go-tuf v0.0.0-20211018154110-b7b6ddad25b5 h1:1AUNRzQMlJV/rvCViSUrgTycbhdN0uitkclLAVNw6q8=
+github.com/asraa/go-tuf v0.0.0-20211018154110-b7b6ddad25b5/go.mod h1:BeoQvv7b+dWjjIWXghwBzUPEY5FZZua52JVbC6/maiw=
 github.com/aws/aws-lambda-go v1.13.3/go.mod h1:4UKl9IzQMoD+QF79YdCuzCwp8VbmG4VAQwij/eHl5CU=
 github.com/aws/aws-sdk-go v1.15.11/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=
 github.com/aws/aws-sdk-go v1.15.27/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

* Fixes key revocation when revoking the root keys from the snapshot and timestamp roles (that are now online) https://github.com/theupdateframework/go-tuf/issues/167
* Correctly sets the thresholds for root and targets (3 out of 5 keyholders) and for snapshot and timestamp (1 online key)
* Increases the expires for snapshot/timestamp to 3 weeks to allow a buffer for the biweekly signing
* Fixes the bug with adding signatures. `AddOrUpdateSignature` from go-tuf doesn't handle our placeholder signatures 


Supersedes https://github.com/sigstore/root-signing/pull/35

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
