### PR TITLE
Upload TUF metadata in reverse read order to avoid errors

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -42,4 +42,10 @@ jobs:
       # TODO(asraa): Use a stable API or switch to gsutil cp when gsutil supports  workload identity federation
       - name: sync
         run: |
-          gcloud alpha --quiet storage cp --cache-control=no-store -r repository/repository/* gs://sigstore-tuf-root/
+          # Upload all but TUF timestamp. Once timestamp is uploaded, all other files must uploaded.
+          for f in $(ls repository/repository/ -I *timestamp.json)
+          do
+            gcloud alpha --quiet storage cp --cache-control=no-store -r repository/repository/$f gs://sigstore-tuf-root/
+          end
+          # Upload timestamp
+          gcloud alpha --quiet storage cp --cache-control=no-store -r repository/repository/*timestamp.json gs://sigstore-tuf-root/


### PR DESCRIPTION
If a timestamp is downloaded before a snapshot is uploaded
for example, then there will be a msimatch in metadata. Once
consistent snapshots are enabled, in combination with this PR,
then a mismatch will not occur, since the last file to be uploaded
will be a timestamp, which will reference a versioned snapshot
(which will then reference versioned targets).

More details in #171.

Signed-off-by: Hayden Blauzvern <hblauzvern@google.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
