### PR TITLE
scripts: fix PR compare URLs

### DIFF
--- a/scripts/step-1.5.sh
+++ b/scripts/step-1.5.sh
@@ -106,5 +106,5 @@ git push -f origin setup-root
 # Open the browser
 export GITHUB_URL=$(git remote -v | awk '/^upstream/{print $2}'| head -1 | sed -Ee 's#(git@|git://)#https://#' -e 's@com:@com/@' -e 's#\.git$##')
 export CHANGE_BRANCH=$(git symbolic-ref HEAD | cut -d"/" -f 3,4)
-export PR_URL=${GITHUB_URL}"/compare/${BRANCH}..."${CHANGE_BRANCH}"?expand=1"
+export PR_URL=${GITHUB_URL}"/compare/${BRANCH}..."${GITHUB_USER}:${CHANGE_BRANCH}"?expand=1"
 open "${PR_URL}" || xdg-open "${PR_URL}"

--- a/scripts/step-1.sh
+++ b/scripts/step-1.sh
@@ -50,5 +50,5 @@ git push -f origin add-key
 # Open the browser
 export GITHUB_URL=$(git remote -v | awk '/^upstream/{print $2}'| head -1 | sed -Ee 's#(git@|git://)#https://#' -e 's@com:@com/@' -e 's#\.git$##')
 export CHANGE_BRANCH=$(git symbolic-ref HEAD | cut -d"/" -f 3,4)
-export PR_URL=${GITHUB_URL}"/compare/${BRANCH}..."${CHANGE_BRANCH}"?expand=1"
+export PR_URL=${GITHUB_URL}"/compare/${BRANCH}..."${GITHUB_USER}:${CHANGE_BRANCH}"?expand=1"
 open "${PR_URL}" || xdg-open "${PR_URL}"

--- a/scripts/step-2.sh
+++ b/scripts/step-2.sh
@@ -57,5 +57,5 @@ git push -f origin sign-root-targets
 # Open the browser
 export GITHUB_URL=$(git remote -v | awk '/^upstream/{print $2}'| head -1 | sed -Ee 's#(git@|git://)#https://#' -e 's@com:@com/@' -e 's#\.git$##')
 export CHANGE_BRANCH=$(git symbolic-ref HEAD | cut -d"/" -f 3,4)
-export PR_URL=${GITHUB_URL}"/compare/${BRANCH}..."${CHANGE_BRANCH}"?expand=1"
+export PR_URL=${GITHUB_URL}"/compare/${BRANCH}..."${GITHUB_USER}:${CHANGE_BRANCH}"?expand=1"
 open "${PR_URL}" || xdg-open "${PR_URL}"

--- a/scripts/step-3.sh
+++ b/scripts/step-3.sh
@@ -56,5 +56,5 @@ git push -f origin sign-delegations
 # Open the browser
 export GITHUB_URL=$(git remote -v | awk '/^upstream/{print $2}'| head -1 | sed -Ee 's#(git@|git://)#https://#' -e 's@com:@com/@' -e 's#\.git$##')
 export CHANGE_BRANCH=$(git symbolic-ref HEAD | cut -d"/" -f 3,4)
-export PR_URL=${GITHUB_URL}"/compare/${BRANCH}..."${CHANGE_BRANCH}"?expand=1"
+export PR_URL=${GITHUB_URL}"/compare/${BRANCH}..."${GITHUB_USER}:${CHANGE_BRANCH}"?expand=1"
 open "${PR_URL}" || xdg-open "${PR_URL}"

--- a/scripts/step-4.sh
+++ b/scripts/step-4.sh
@@ -56,5 +56,5 @@ git push -f origin sign-snapshot
 # Open the browser
 export GITHUB_URL=$(git remote -v | awk '/^upstream/{print $2}'| head -1 | sed -Ee 's#(git@|git://)#https://#' -e 's@com:@com/@' -e 's#\.git$##')
 export CHANGE_BRANCH=$(git symbolic-ref HEAD | cut -d"/" -f 3,4)
-export PR_URL=${GITHUB_URL}"/compare/${BRANCH}..."${CHANGE_BRANCH}"?expand=1"
+export PR_URL=${GITHUB_URL}"/compare/${BRANCH}..."${GITHUB_USER}:${CHANGE_BRANCH}"?expand=1"
 open "${PR_URL}" || xdg-open "${PR_URL}"

--- a/scripts/step-5.sh
+++ b/scripts/step-5.sh
@@ -46,5 +46,5 @@ git push -f origin publish
 # Open the browser
 export GITHUB_URL=$(git remote -v | awk '/^upstream/{print $2}'| head -1 | sed -Ee 's#(git@|git://)#https://#' -e 's@com:@com/@' -e 's#\.git$##')
 export CHANGE_BRANCH=$(git symbolic-ref HEAD | cut -d"/" -f 3,4)
-export PR_URL=${GITHUB_URL}"/compare/${BRANCH}..."${CHANGE_BRANCH}"?expand=1"
+export PR_URL=${GITHUB_URL}"/compare/${BRANCH}..."${GITHUB_USER}:${CHANGE_BRANCH}"?expand=1"
 open "${PR_URL}" || xdg-open "${PR_URL}"


### PR DESCRIPTION
Compare the GITHUB_USER's (origin) branch to the upstream branch

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

When the scripts open a PR url they should compare the user's fork to the upstream branch (not the user's branch on the upstream repository).

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
