### PR TITLE
presubmit: add github workflow that tests cosign initialize

### DIFF
--- a/.github/workflows/cosign-test.yml
+++ b/.github/workflows/cosign-test.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           fetch-depth: 2
       - run: |
-          cd repository/
+          cd repository/repository/
           python -m http.server 8001 &
           echo "REPO=http://localhost:8001" >> $GITHUB_ENV
       

--- a/.github/workflows/cosign-test.yml
+++ b/.github/workflows/cosign-test.yml
@@ -1,0 +1,35 @@
+name: Cosign tests
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+    paths:
+      - 'repository/**'
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  validate:
+    env:
+      COSIGN_EXPERIMENTAL: "true"
+    runs-on: ubuntu-20.04
+    steps:
+      # Install cosign
+      - uses: sigstore/cosign-installer@536b37ec5d5b543420bdfd9b744c5965bd4d8730 # v2.3.0
+      
+      # Set up a repository server with python
+      - uses: actions/setup-python@v3
+        with:
+          python-version: '3.x' 
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v2.4.0
+        with:
+          fetch-depth: 2
+      - run: |
+          cd repository/
+          python -m http.server 8001
+          echo "REPO=http://localhost:8001" >> $GITHUB_ENV
+      
+      # Test cosign initialize
+      - name: cosign initialize on published repository
+        run: cosign initialize --mirror http://localhost:8001

--- a/.github/workflows/cosign-test.yml
+++ b/.github/workflows/cosign-test.yml
@@ -27,7 +27,7 @@ jobs:
           fetch-depth: 2
       - run: |
           cd repository/
-          python -m http.server 8001
+          python -m http.server 8001 &
           echo "REPO=http://localhost:8001" >> $GITHUB_ENV
       
       # Test cosign initialize

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,11 +2,11 @@ name: CI Test
 
 on:
   push:
-    branches: [ main, v3-staging ]
+    branches: [ main ]
     paths-ignore:
       - 'ceremony/**'
   pull_request:
-    branches: [ main, v3-staging ]
+    branches: [ main ]
     paths-ignore:
       - 'ceremony/**'
 


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Part of https://github.com/sigstore/root-signing/issues/240
This will hopefully catch some issues on the publishing PR before the sync workflow on push triggers to the GCS bucket.
Once `cosign initialize` and `cosign verify` flows are the same, this will hopefully catch all issues.

It's infeasible to really test `cosign verify` until the flows are merged, since this tests before the bucket is updated.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
