### PR TITLE
Add GitHub Actions workflow to sync preprod and prod

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -39,13 +39,23 @@ jobs:
           gcloud auth login --brief --cred-file="${{ steps.auth.outputs.credentials_file_path }}"
           gcloud auth list
       # Sync
-      # TODO(asraa): Use a stable API or switch to gsutil cp when gsutil supports  workload identity federation
+      # TODO(297): Switch to stable gcloud API, use rsync when available
       - name: sync
         run: |
-          # Upload all but TUF timestamp. Once timestamp is uploaded, all other files must uploaded.
+          # Upload all but TUF timestamp. Once timestamp is uploaded, all other files must have been uploaded.
           for f in $(ls repository/repository/ -I *timestamp.json)
           do
             gcloud alpha --quiet storage cp --cache-control=no-store -r repository/repository/$f gs://sigstore-preprod-tuf-root/
           done
           # Upload timestamp
           gcloud alpha --quiet storage cp --cache-control=no-store -r repository/repository/*timestamp.json gs://sigstore-preprod-tuf-root/
+
+          # delete any files present in sigstore-preprod-tuf-root not in repository/repository
+          gcloud alpha --quiet storage cp -r gs://sigstore-preprod-tuf-root/ .
+
+          diff -qr repository/repository sigstore-preprod-tuf-root | while read l; do
+            if [[ $l =~ "Only in sigstore-preprod-tuf-root" ]]; then
+              path=$(python3 -c "import re; s='$l'; pattern=r'^Only in sigstore-preprod-tuf-root(\/?)(.*): (.*)$'; match=re.search(pattern, s); print('/'.join([match.group(2), match.group(3)]).lstrip('/'))")
+              gcloud alpha --quiet storage rm gs://sigstore-preprod-tuf-root/$path
+            fi;
+          done

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,4 +1,4 @@
-name: Sync Repository with GCS
+name: Sync Repository with GCS Preprod Bucket
 
 # Execute this on changes to repository/repository/
 on:
@@ -45,7 +45,7 @@ jobs:
           # Upload all but TUF timestamp. Once timestamp is uploaded, all other files must uploaded.
           for f in $(ls repository/repository/ -I *timestamp.json)
           do
-            gcloud alpha --quiet storage cp --cache-control=no-store -r repository/repository/$f gs://sigstore-tuf-root/
+            gcloud alpha --quiet storage cp --cache-control=no-store -r repository/repository/$f gs://sigstore-preprod-tuf-root/
           done
           # Upload timestamp
-          gcloud alpha --quiet storage cp --cache-control=no-store -r repository/repository/*timestamp.json gs://sigstore-tuf-root/
+          gcloud alpha --quiet storage cp --cache-control=no-store -r repository/repository/*timestamp.json gs://sigstore-preprod-tuf-root/

--- a/.github/workflows/sync_to_prod.yml
+++ b/.github/workflows/sync_to_prod.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Install tools
         run: |
           sudo apt-get install -y jq
+      # TODO(297): Switch to stable gcloud API, use rsync when available
       - name: sync
         run: |
           difference() {
@@ -49,7 +50,7 @@ jobs:
           timeCreatedProd=$(echo $tsMeta | jq .timeCreated)
           md5HashProd=$(echo $tsMeta | jq .md5Hash)
 
-          # if less than 2 days, do not update
+          # if less than 2 days since updates were published to preprod, do not update
           daysDiff=$(difference $timeCreatedPreprod $timeCreatedProd)
           if (($daysDiff < 2)); then
             exit 0 
@@ -59,13 +60,15 @@ jobs:
             exit 0
           fi
 
+          # download preprod bucket and copy over to production bucket
           gcloud alpha --quiet storage cp -r gs://sigstore-preprod-tuf-root/ .
 
+          # upload all but TUF timestamp. Once timestamp is uploaded, all other files must have been uploaded.
           for f in $(ls sigstore-preprod-tuf-root/ -I *timestamp.json)
           do
             gcloud alpha --quiet storage cp --cache-control=no-store -r sigstore-preprod-tuf-root/$f gs://sigstore-tuf-root/
           done
-          # Upload timestamp
+          # upload timestamp
           gcloud alpha --quiet storage cp --cache-control=no-store -r sigstore-preprod-tuf-root/*timestamp.json gs://sigstore-tuf-root/
 
           # delete any files present in sigstore-tuf-root not in sigstore-preprod-tuf-root

--- a/.github/workflows/sync_to_prod.yml
+++ b/.github/workflows/sync_to_prod.yml
@@ -1,0 +1,80 @@
+name: Sync Preprod Repository with GCS Prod Bucket 
+
+on:
+  schedule:
+    - cron: '0 */12 * * *' # every 12 hours
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-20.04
+    permissions:
+      id-token: 'write'
+    steps:
+      - uses: google-github-actions/setup-gcloud@877d4953d2c70a0ba7ef3290ae968eb24af233bb # v0.5.1
+        with:
+          project_id: project-rekor
+          install_components: alpha
+      # Setup OIDC->SA auth
+      - uses: google-github-actions/auth@dafc92490a98acbdec38e6eb649f05d55e632447 # v0.7.2
+        id: auth
+        with:
+          token_format: 'access_token'
+          workload_identity_provider: 'projects/237800849078/locations/global/workloadIdentityPools/root-signing-pool/providers/sigstore-root'
+          service_account: 'sigstore-root-signing@project-rekor.iam.gserviceaccount.com'
+          create_credentials_file: true
+      - name: login
+        run: |
+          gcloud auth login --brief --cred-file="${{ steps.auth.outputs.credentials_file_path }}"
+          gcloud auth list
+      - name: Install tools
+        run: |
+          sudo apt-get install -y jq
+      - name: sync
+        run: |
+          difference() {
+            date_one=$(date -d "$1" +%s)
+            date_two=$(date -d "$2" +%s)
+            echo $(( (date_one - date_two) / 86400 ))
+          }
+
+          # fetch creation time and hash for timestamp in preprod
+          # timestamp is always updated on a sync, either from the weekly updates or the signing ceremony
+          tsMetaPreprod=$(gcloud alpha storage ls --json gs://sigstore-preprod-tuf-root/timestamp.json | jq .[0].metadata)
+          timeCreatedPreprod=$(echo $tsMeta | jq .timeCreated)
+          md5HashPreprod=$(echo $tsMeta | jq .md5Hash)
+
+          # fetch creation time and hash for timestamp in prod
+          tsMetaProd=$(gcloud alpha storage ls --json gs://sigstore-tuf-root/timestamp.json | jq .[0].metadata)
+          timeCreatedProd=$(echo $tsMeta | jq .timeCreated)
+          md5HashProd=$(echo $tsMeta | jq .md5Hash)
+
+          # if less than 2 days, do not update
+          daysDiff=$(difference $timeCreatedPreprod $timeCreatedProd)
+          if (($daysDiff < 2)); then
+            exit 0 
+          fi
+          # exit early if already updated
+          if [[ "$md5HashPreprod" == "$md5HashProd" ]]; then
+            exit 0
+          fi
+
+          gcloud alpha --quiet storage cp -r gs://sigstore-preprod-tuf-root/ .
+
+          for f in $(ls sigstore-preprod-tuf-root/ -I *timestamp.json)
+          do
+            gcloud alpha --quiet storage cp --cache-control=no-store -r sigstore-preprod-tuf-root/$f gs://sigstore-tuf-root/
+          done
+          # Upload timestamp
+          gcloud alpha --quiet storage cp --cache-control=no-store -r sigstore-preprod-tuf-root/*timestamp.json gs://sigstore-tuf-root/
+
+          # delete any files present in sigstore-tuf-root not in sigstore-preprod-tuf-root
+          gcloud alpha --quiet storage cp -r gs://sigstore-tuf-root/ .
+
+          diff -qr sigstore-preprod-tuf-root sigstore-tuf-root | while read l; do
+            if [[ $l =~ "sigstore-tuf-root" ]]; then
+              prefix="Only in sigstore-tuf-root: "
+              path=${l#"$prefix"}
+              gcloud alpha --quiet storage rm gs://sigstore-tuf-root/$path
+            fi;
+          done

--- a/.github/workflows/sync_to_prod.yml
+++ b/.github/workflows/sync_to_prod.yml
@@ -72,9 +72,8 @@ jobs:
           gcloud alpha --quiet storage cp -r gs://sigstore-tuf-root/ .
 
           diff -qr sigstore-preprod-tuf-root sigstore-tuf-root | while read l; do
-            if [[ $l =~ "sigstore-tuf-root" ]]; then
-              prefix="Only in sigstore-tuf-root: "
-              path=${l#"$prefix"}
+            if [[ $l =~ "Only in sigstore-tuf-root" ]]; then
+              path=$(python3 -c "import re; s='$l'; pattern=r'^Only in sigstore-tuf-root(\/?)(.*): (.*)$'; match=re.search(pattern, s); print('/'.join([match.group(2), match.group(3)]).lstrip('/'))")
               gcloud alpha --quiet storage rm gs://sigstore-tuf-root/$path
             fi;
           done

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -19,6 +19,7 @@ jobs:
       - run: |
           echo "REPO=$(pwd)/repository" >> $GITHUB_ENV
           echo "GCS_REPO=https://storage.googleapis.com/sigstore-tuf-root" >> $GITHUB_ENV
+          echo "GCS_PREPROD_REPO=https://storage.googleapis.com/sigstore-preprod-tuf-root" >> $GITHUB_ENV
       - uses: actions/setup-go@b22fbbc2921299758641fab08929b4ac52b32923 # v2.2.0
         with:
           go-version: '1.17.x'
@@ -34,6 +35,8 @@ jobs:
         run: ./verify repository --repository $REPO --root $(pwd)/ceremony/2021-06-18/repository/root.json
       - name: verify GCS remote published repository
         run: ./verify repository --repository $GCS_REPO --root $(pwd)/ceremony/2021-06-18/repository/root.json
+      - name: verify GCS preprod remote published repository
+        run: ./verify repository --repository $GCS_PREPROD_REPO --root $(pwd)/ceremony/2021-06-18/repository/root.json
       - name: verify staged ceremony changes
         run: |
           set -euo pipefail


### PR DESCRIPTION
This workflow runs every 12 hours, checking if at least 2 days has
passed to let preprod first be used, and checking if the metadata has
already been updated.

Signed-off-by: Hayden Blauzvern <hblauzvern@google.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes #121, #243

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
