### PR TITLE
test: add regression test to ensure snapshotting fails if root/targets invalid

### DIFF
--- a/cmd/tuf/app/init.go
+++ b/cmd/tuf/app/init.go
@@ -256,6 +256,24 @@ func setMetaWithSigKeyIDs(store tuf.LocalStore, role string, meta interface{}, k
 	return setSignedMeta(store, role, &data.Signed{Signatures: emptySigs, Signed: signed})
 }
 
+func ClearEmptySignatures(store tuf.LocalStore, role string) error {
+	signedMeta, err := prepo.GetSignedMeta(store, role)
+	if err != nil {
+		return err
+	}
+
+	sigs := make([]data.Signature, 0, 1)
+	for _, signature := range signedMeta.Signatures {
+		if len(signature.Signature) == 0 {
+			// Skip placeholder signatures.
+			continue
+		}
+		sigs = append(sigs, signature)
+	}
+
+	return setSignedMeta(store, role, &data.Signed{Signatures: sigs, Signed: signedMeta.Signed})
+}
+
 func jsonMarshal(v interface{}) ([]byte, error) {
 	b, err := cjson.Marshal(v)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -188,7 +188,7 @@ require (
 	golang.org/x/net v0.0.0-20220520000938-2e3eb7b945c2 // indirect
 	golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5 // indirect
 	golang.org/x/sync v0.0.0-20220513210516-0976fa681c29 // indirect
-	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a // indirect
+	golang.org/x/sys v0.0.0-20220610221304-9f5ed59c137d // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20220411224347-583f2d630306 // indirect
 	golang.org/x/tools v0.1.10 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2774,6 +2774,8 @@ golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220502124256-b6088ccd6cba/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220610221304-9f5ed59c137d h1:Zu/JngovGLVi6t2J3nmAf3AoTDwuzw85YZ3b9o4yU7s=
+golang.org/x/sys v0.0.0-20220610221304-9f5ed59c137d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -33,7 +33,7 @@ checkout_branch() {
     git rev-parse HEAD
 }
 
-cleanup_branchs() {
+cleanup_branches() {
     git branch -D setup-root || true
     git branch -D add-key || true
     git branch -D sign-root-targets || true

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -119,3 +119,57 @@ func TestInitCmd(t *testing.T) {
 		}
 	}
 }
+
+func TestSnapshotUnvalidatedFails(t *testing.T) {
+	ctx := context.Background()
+	td := t.TempDir()
+
+	testTarget := filepath.Join(td, "foo.txt")
+	targetsConfig := map[string]json.RawMessage{testTarget: nil}
+
+	if err := os.WriteFile(testTarget, []byte("abc"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := createTestHsmKey(td); err != nil {
+		t.Fatal(err)
+	}
+
+	snapshotKey := createTestSigner(t)
+	timestampKey := createTestSigner(t)
+
+	// Initialize succeeds.
+	if err := app.InitCmd(ctx, td, "", 1, targetsConfig, snapshotKey, timestampKey); err != nil {
+		t.Fatal(err)
+	}
+
+	// Validate that root and targets have one unfilled signature.
+	// TODO: When #281 is merged, add a test with a valid threshold achieved
+	// but an additional invalid sig.
+	store := tuf.FileSystemStore(td, nil)
+	meta, err := store.GetMeta()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, metaName := range []string{"root.json", "targets.json"} {
+		md, ok := meta[metaName]
+		if !ok {
+			t.Fatalf("missing %s", metaName)
+		}
+		signed := &data.Signed{}
+		if err := json.Unmarshal(md, signed); err != nil {
+			t.Fatal(err)
+		}
+		if len(signed.Signatures) != 1 {
+			t.Fatalf("expected 1 signature on %s", metaName)
+		}
+		if len(signed.Signatures[0].Signature) != 0 {
+			t.Fatalf("expected empty signature for key ID %s", signed.Signatures[0].KeyID)
+		}
+	}
+
+	// Try to snapshot. Expect to fail.
+	if err := app.SnapshotCmd(ctx, td); err == nil {
+		t.Fatalf("expected Snapshot command to fail")
+	}
+}

--- a/tests/keygen/main.go
+++ b/tests/keygen/main.go
@@ -1,3 +1,6 @@
+//go:build pivkey
+// +build pivkey
+
 package main
 
 import "github.com/sigstore/root-signing/tests/keygen/app"


### PR DESCRIPTION
Fixes https://github.com/sigstore/root-signing/issues/238

This is fixed upstream in go-tuf: we will now fail in `SnapshotCmd` if the root and/or targets are invalid (not signed).

Signed-off-by: Asra Ali <asraa@google.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
