### PR TITLE
fix: delegations terminating and configuration 

### DIFF
--- a/config/revocation-metadata.yml
+++ b/config/revocation-metadata.yml
@@ -1,2 +1,2 @@
 # Target files and metadata under revocation delegation
-targets/revocation.list: "" 
+targets/revocation.list:

--- a/scripts/step-1.5.sh
+++ b/scripts/step-1.5.sh
@@ -53,7 +53,7 @@ mkdir -p ${REPO}/staged/targets
 # Setup the root and targets
 ./tuf init -repository $REPO -target-meta config/targets-metadata.yml -snapshot ${SNAPSHOT_KEY} -timestamp ${TIMESTAMP_KEY} -previous "${PREV_REPO}"
 # Add rekor delegation
-./tuf add-delegation -repository $REPO -name "rekor" -key $REKOR_KEY -path "rekor.*.pub" -target-meta config/rekor-metadata.yml
+./tuf add-delegation -repository $REPO -name "rekor" -key $REKOR_KEY -path "rekor.*.pub" -target-meta config/rekor-metadata.yml -terminating true
 # Add staging project delegation
 ./tuf add-delegation -repository $REPO -name "staging" -key $STAGING_KEY -path "*"
 # Add revoked project delegation


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Fixes:
* Adds a configurable flag to specify whether delegation is terminating
* Fixes a small empty string/nil custom metadata parsing in the revocation configuration

Fixes
https://github.com/sigstore/root-signing/issues/290

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
