### PR TITLE
fix: use newline removed metadata

### DIFF
--- a/scripts/step-1.5.sh
+++ b/scripts/step-1.5.sh
@@ -56,7 +56,7 @@ if [[ -n $1 ]]; then
 fi
 # TODO(asraa): We need to copy up-to-date snapshot and timestamp from the published
 # repository. Ideally we'd chain from `repository/repository`: see https://github.com/sigstore/root-signing/issues/288
-cp repository/repository/{snapshot.json,timestamp.json} ${REPO}/repository
+cp -r repository/repository/* ${REPO}/repository
 
 # Setup the root and targets
 ./tuf init -repository $REPO -target-meta config/targets-metadata.yml -snapshot ${SNAPSHOT_KEY} -timestamp ${TIMESTAMP_KEY} -previous "${PREV_REPO}"

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -37,8 +37,10 @@ if [[ ! -z "$1" ]]; then
     git checkout VERIFY
 fi
 
-# Verify keys
-./verify keys --root piv-attestation-ca.pem --key-directory $REPO/keys
+# Verify keys if keys/ repository exists. It does not in the top-level published repository/
+if [ -d $REPO/keys ]; then
+    ./verify keys --root piv-attestation-ca.pem --key-directory $REPO/keys
+fi
 # If staged metadata exists, verify the staged repository
 if [ -f $REPO/staged/root.json ]; then
     ./verify repository --repository $REPO --staged


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->
Because https://github.com/sigstore/root-signing/issues/287 removed newlines in root/targets, we have to copy over the updated `repository/` root/targets, or else there's a length mismatch from the updated snapshot.json

Also makes one more fix so we can cleanly run `./scripts/verify.sh` on the top-level `repository/` (right now no keys are stored: https://github.com/sigstore/root-signing/issues/288)

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
