### PR TITLE
Capture gcloud CLI pre-requisite for key holders

### DIFF
--- a/KEYHOLDER.md
+++ b/KEYHOLDER.md
@@ -11,6 +11,7 @@ Keyholders MUST subscribe to the [Sigstore Maintainer Calendar](https://calendar
 Ensure you have the following:
 - [ ] A local Git installation and a Go development setup
 - [ ] SSH authentication for GitHub (see [here](https://docs.github.com/en/authentication/connecting-to-github-with-ssh))
+- [ ] [gcloud CLI](https://cloud.google.com/sdk/docs/install) installed and initialized
 - [ ] A USB port connection for your hardware key (beware of using a remote connection; the keyholder should not assume that magic occurs during an SSH session)
 
 ### Signing pre-work


### PR DESCRIPTION
#### Summary
Keyholders need gcloud CLI installed, add it to prerequisites in KEYHOLDERS.md

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->