### PR TITLE
fix: accidentally mixed key cert and pubkey path

### DIFF
--- a/cmd/verify/app/keys.go
+++ b/cmd/verify/app/keys.go
@@ -111,8 +111,8 @@ func verifySigningKeys(dirname string, rootCA *x509.Certificate) (*KeyMap, error
 
 	log.Printf("\n# Manually extract the public key for any key ID and match with published\n\n")
 	log.Printf("\texport SERIAL_NUMBER=${SERIAL_NUMBER}")
-	log.Printf("\topenssl x509 -in %s -pubkey -noout", pubkeyPath)
-	log.Printf("\tcat %s", keyPath)
+	log.Printf("\topenssl x509 -in %s -pubkey -noout", keyPath)
+	log.Printf("\tcat %s", pubkeyPath)
 
 	return &keyMap, nil
 }


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
* fix: fixes openssl command to extract pubkey from KEY CERT and cat the PUBKEY.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->