### PR TITLE
Add failing python-tuf client test

### DIFF
--- a/.github/workflows/tuf_client_tests.yml
+++ b/.github/workflows/tuf_client_tests.yml
@@ -47,6 +47,7 @@ jobs:
             -t http://localhost:8001/targets \
             -m http://localhost:8001
       # Test with python-tuf ngclient
-      - run: |
+      - continue-on-error: true # remove once v5 root is published
+        run: |
           python3 -m pip install securesystemslib[crypto,pynacl] tuf
           python3 tests/client-tests/python-tuf.py

--- a/.github/workflows/tuf_client_tests.yml
+++ b/.github/workflows/tuf_client_tests.yml
@@ -46,3 +46,7 @@ jobs:
             --root repository/repository/2.root.json \
             -t http://localhost:8001/targets \
             -m http://localhost:8001
+      # Test with python-tuf ngclient
+      - run: |
+          python3 -m pip install securesystemslib[crypto,pynacl] tuf
+          python3 tests/client-tests/python-tuf.py

--- a/tests/client-tests/python-tuf.py
+++ b/tests/client-tests/python-tuf.py
@@ -1,0 +1,42 @@
+#
+# Copyright 2022 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import shutil
+import tempfile
+
+from tuf.ngclient import Updater
+
+REPO_URL = os.getenv("REPO")
+
+with tempfile.TemporaryDirectory() as tmpdirname:
+    METADATA_DIR = f"{tmpdirname}/metadata"
+    os.mkdir(METADATA_DIR)
+
+    # Copy in root metadata to use as trusted root
+    # NOTE: we have to use v5 or newer, once it exists, because prior versions
+    # were not compatible with python-tuf:
+    # https://github.com/sigstore/root-signing/issues/103
+    # https://github.com/sigstore/root-signing/issues/329
+    shutil.copyfile(
+        "repository/repository/4.root.json",
+        f"{METADATA_DIR}/root.json")
+
+    updater = Updater(
+        metadata_dir=METADATA_DIR,
+        metadata_base_url=f"{REPO_URL}/metadata/",
+        target_base_url=f"{REPO_URL}/targets/",
+        target_dir=tmpdirname)
+    updater.refresh()


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Adds a simple python-tuf client in tests/client-tests/python-tuf.py, the client currently fails due to #329 which will be resolved with the v5 root.

Fixes #242 

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
NONE

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->