### PR TITLE
feat: Allow parsing HSM and online keys with deprecated and new PEM format

### DIFF
--- a/cmd/tuf/app/add-delegation.go
+++ b/cmd/tuf/app/add-delegation.go
@@ -102,7 +102,7 @@ func DelegationCmd(ctx context.Context, directory, name, path string, terminatin
 	keys := []*data.PublicKey{}
 	ids := []string{}
 	for _, keyRef := range keyRefs {
-		signerKey, err := pkeys.GetSigningKey(ctx, keyRef)
+		signerKey, err := pkeys.GetSigningKey(ctx, keyRef, true)
 		if err != nil {
 			return err
 		}

--- a/cmd/tuf/app/add-delegation.go
+++ b/cmd/tuf/app/add-delegation.go
@@ -102,7 +102,7 @@ func DelegationCmd(ctx context.Context, directory, name, path string, terminatin
 	keys := []*data.PublicKey{}
 	ids := []string{}
 	for _, keyRef := range keyRefs {
-		signerKey, err := pkeys.GetSigningKey(ctx, keyRef, true)
+		signerKey, err := pkeys.GetSigningKey(ctx, keyRef, DeprecatedEcdsaFormat)
 		if err != nil {
 			return err
 		}

--- a/cmd/tuf/app/init.go
+++ b/cmd/tuf/app/init.go
@@ -40,6 +40,9 @@ var DefaultThreshold = 3
 // Enable consistent snapshotting.
 var ConsistentSnapshot = true
 
+// Use deprecated hex-encoded ECDSA keys.
+var DeprecatedEcdsaFormat = true
+
 // Time to role expiration represented as a list of ints corresponding to
 // (years, months, days).
 var RoleExpiration = map[string][]int{
@@ -188,7 +191,7 @@ func InitCmd(ctx context.Context, directory, previous string, threshold int, tar
 
 	// Add keys used for snapshot and timestamp roles.
 	for role, keyRef := range map[string]string{"snapshot": snapshotRef, "timestamp": timestampRef} {
-		signerKey, err := pkeys.GetSigningKey(ctx, keyRef, true)
+		signerKey, err := pkeys.GetSigningKey(ctx, keyRef, DeprecatedEcdsaFormat)
 		if err != nil {
 			return err
 		}
@@ -343,7 +346,7 @@ func getKeysFromDir(dir string) ([]*data.PublicKey, error) {
 			if err != nil {
 				return nil, err
 			}
-			tufKey, err := pkeys.ToTufKey(*key, true)
+			tufKey, err := pkeys.ToTufKey(*key, DeprecatedEcdsaFormat)
 			if err != nil {
 				return nil, err
 			}

--- a/cmd/tuf/app/init.go
+++ b/cmd/tuf/app/init.go
@@ -149,7 +149,7 @@ func InitCmd(ctx context.Context, directory, previous string, threshold int, tar
 	}
 	keys, err := getKeysFromDir(directory + "/keys")
 	if err != nil {
-		return err
+		return fmt.Errorf("getting HSM keys: %s", err)
 	}
 	var allRootKeys []*data.PublicKey
 	// Add any keys in the keys/ subfolder to root and targets.
@@ -188,7 +188,7 @@ func InitCmd(ctx context.Context, directory, previous string, threshold int, tar
 
 	// Add keys used for snapshot and timestamp roles.
 	for role, keyRef := range map[string]string{"snapshot": snapshotRef, "timestamp": timestampRef} {
-		signerKey, err := pkeys.GetSigningKey(ctx, keyRef)
+		signerKey, err := pkeys.GetSigningKey(ctx, keyRef, true)
 		if err != nil {
 			return err
 		}
@@ -343,7 +343,7 @@ func getKeysFromDir(dir string) ([]*data.PublicKey, error) {
 			if err != nil {
 				return nil, err
 			}
-			tufKey, err := pkeys.ToTufKey(*key)
+			tufKey, err := pkeys.ToTufKey(*key, true)
 			if err != nil {
 				return nil, err
 			}

--- a/cmd/tuf/app/sign.go
+++ b/cmd/tuf/app/sign.go
@@ -140,7 +140,7 @@ func getSigner(ctx context.Context, sk bool, keyRef string) (*keys.SignerAndTufK
 		return &keys.SignerAndTufKey{Signer: signer, Key: keyAndAttestations.Key}, nil
 	}
 	// A key reference was provided.
-	return keys.GetSigningKey(ctx, keyRef)
+	return keys.GetSigningKey(ctx, keyRef, true)
 }
 
 func SignCmd(ctx context.Context, directory string, roles []string, signer *keys.SignerAndTufKey) error {

--- a/cmd/tuf/app/sign.go
+++ b/cmd/tuf/app/sign.go
@@ -140,7 +140,7 @@ func getSigner(ctx context.Context, sk bool, keyRef string) (*keys.SignerAndTufK
 		return &keys.SignerAndTufKey{Signer: signer, Key: keyAndAttestations.Key}, nil
 	}
 	// A key reference was provided.
-	return keys.GetSigningKey(ctx, keyRef, true)
+	return keys.GetSigningKey(ctx, keyRef, DeprecatedEcdsaFormat)
 }
 
 func SignCmd(ctx context.Context, directory string, roles []string, signer *keys.SignerAndTufKey) error {

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -389,7 +389,7 @@ func TestPublishSuccess(t *testing.T) {
 	if err := app.SnapshotCmd(ctx, td); err != nil {
 		t.Fatalf("expected Snapshot command to pass, got err: %s", err)
 	}
-	snapshotSigner, err := keys.GetSigningKey(ctx, snapshotKey, true)
+	snapshotSigner, err := keys.GetSigningKey(ctx, snapshotKey, app.DeprecatedEcdsaFormat)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -400,7 +400,7 @@ func TestPublishSuccess(t *testing.T) {
 	if err := app.TimestampCmd(ctx, td); err != nil {
 		t.Fatalf("expected Timestamp command to pass, got err: %s", err)
 	}
-	timestampSigner, err := keys.GetSigningKey(ctx, timestampKey, true)
+	timestampSigner, err := keys.GetSigningKey(ctx, timestampKey, app.DeprecatedEcdsaFormat)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -503,7 +503,7 @@ func TestRotateRootKey(t *testing.T) {
 	if err := app.SnapshotCmd(ctx, td); err != nil {
 		t.Fatalf("expected Snapshot command to pass, got err: %s", err)
 	}
-	snapshotSigner, err := keys.GetSigningKey(ctx, snapshotKey, true)
+	snapshotSigner, err := keys.GetSigningKey(ctx, snapshotKey, app.DeprecatedEcdsaFormat)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -514,7 +514,7 @@ func TestRotateRootKey(t *testing.T) {
 	if err := app.TimestampCmd(ctx, td); err != nil {
 		t.Fatalf("expected Timestamp command to pass, got err: %s", err)
 	}
-	timestampSigner, err := keys.GetSigningKey(ctx, timestampKey, true)
+	timestampSigner, err := keys.GetSigningKey(ctx, timestampKey, app.DeprecatedEcdsaFormat)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -670,7 +670,7 @@ func TestRotateTarget(t *testing.T) {
 	if err := app.SnapshotCmd(ctx, td); err != nil {
 		t.Fatalf("expected Snapshot command to pass, got err: %s", err)
 	}
-	snapshotSigner, err := keys.GetSigningKey(ctx, snapshotKey, true)
+	snapshotSigner, err := keys.GetSigningKey(ctx, snapshotKey, app.DeprecatedEcdsaFormat)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -681,7 +681,7 @@ func TestRotateTarget(t *testing.T) {
 	if err := app.TimestampCmd(ctx, td); err != nil {
 		t.Fatalf("expected Timestamp command to pass, got err: %s", err)
 	}
-	timestampSigner, err := keys.GetSigningKey(ctx, timestampKey, true)
+	timestampSigner, err := keys.GetSigningKey(ctx, timestampKey, app.DeprecatedEcdsaFormat)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -853,7 +853,7 @@ func TestConsistentSnapshotFlip(t *testing.T) {
 	if err := app.SnapshotCmd(ctx, td); err != nil {
 		t.Fatalf("expected Snapshot command to pass, got err: %s", err)
 	}
-	snapshotSigner, err := keys.GetSigningKey(ctx, snapshotKey, true)
+	snapshotSigner, err := keys.GetSigningKey(ctx, snapshotKey, app.DeprecatedEcdsaFormat)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -864,7 +864,7 @@ func TestConsistentSnapshotFlip(t *testing.T) {
 	if err := app.TimestampCmd(ctx, td); err != nil {
 		t.Fatalf("expected Timestamp command to pass, got err: %s", err)
 	}
-	timestampSigner, err := keys.GetSigningKey(ctx, timestampKey, true)
+	timestampSigner, err := keys.GetSigningKey(ctx, timestampKey, app.DeprecatedEcdsaFormat)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -389,7 +389,7 @@ func TestPublishSuccess(t *testing.T) {
 	if err := app.SnapshotCmd(ctx, td); err != nil {
 		t.Fatalf("expected Snapshot command to pass, got err: %s", err)
 	}
-	snapshotSigner, err := keys.GetSigningKey(ctx, snapshotKey)
+	snapshotSigner, err := keys.GetSigningKey(ctx, snapshotKey, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -400,7 +400,7 @@ func TestPublishSuccess(t *testing.T) {
 	if err := app.TimestampCmd(ctx, td); err != nil {
 		t.Fatalf("expected Timestamp command to pass, got err: %s", err)
 	}
-	timestampSigner, err := keys.GetSigningKey(ctx, timestampKey)
+	timestampSigner, err := keys.GetSigningKey(ctx, timestampKey, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -503,7 +503,7 @@ func TestRotateRootKey(t *testing.T) {
 	if err := app.SnapshotCmd(ctx, td); err != nil {
 		t.Fatalf("expected Snapshot command to pass, got err: %s", err)
 	}
-	snapshotSigner, err := keys.GetSigningKey(ctx, snapshotKey)
+	snapshotSigner, err := keys.GetSigningKey(ctx, snapshotKey, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -514,7 +514,7 @@ func TestRotateRootKey(t *testing.T) {
 	if err := app.TimestampCmd(ctx, td); err != nil {
 		t.Fatalf("expected Timestamp command to pass, got err: %s", err)
 	}
-	timestampSigner, err := keys.GetSigningKey(ctx, timestampKey)
+	timestampSigner, err := keys.GetSigningKey(ctx, timestampKey, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -670,7 +670,7 @@ func TestRotateTarget(t *testing.T) {
 	if err := app.SnapshotCmd(ctx, td); err != nil {
 		t.Fatalf("expected Snapshot command to pass, got err: %s", err)
 	}
-	snapshotSigner, err := keys.GetSigningKey(ctx, snapshotKey)
+	snapshotSigner, err := keys.GetSigningKey(ctx, snapshotKey, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -681,7 +681,7 @@ func TestRotateTarget(t *testing.T) {
 	if err := app.TimestampCmd(ctx, td); err != nil {
 		t.Fatalf("expected Timestamp command to pass, got err: %s", err)
 	}
-	timestampSigner, err := keys.GetSigningKey(ctx, timestampKey)
+	timestampSigner, err := keys.GetSigningKey(ctx, timestampKey, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -853,7 +853,7 @@ func TestConsistentSnapshotFlip(t *testing.T) {
 	if err := app.SnapshotCmd(ctx, td); err != nil {
 		t.Fatalf("expected Snapshot command to pass, got err: %s", err)
 	}
-	snapshotSigner, err := keys.GetSigningKey(ctx, snapshotKey)
+	snapshotSigner, err := keys.GetSigningKey(ctx, snapshotKey, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -864,7 +864,7 @@ func TestConsistentSnapshotFlip(t *testing.T) {
 	if err := app.TimestampCmd(ctx, td); err != nil {
 		t.Fatalf("expected Timestamp command to pass, got err: %s", err)
 	}
-	timestampSigner, err := keys.GetSigningKey(ctx, timestampKey)
+	timestampSigner, err := keys.GetSigningKey(ctx, timestampKey, true)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -139,7 +139,7 @@ func GetTestHsmSigner(ctx context.Context, testDir string, serial uint32) (*keys
 	cryptoPub, _ := signer.PublicKey()
 	pub := cryptoPub.(*ecdsa.PublicKey)
 
-	pk, err := keys.EcdsaTufKey(pub)
+	pk, err := keys.EcdsaTufKey(pub, true)
 	if err != nil {
 		return nil, err
 	}
@@ -161,7 +161,7 @@ func CreateTestHsmSigner(testDir string, root *x509.Certificate, rootSigner cryp
 		return nil, err
 	}
 
-	pk, err := keys.EcdsaTufKey(pub)
+	pk, err := keys.EcdsaTufKey(pub, true)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -139,7 +139,7 @@ func GetTestHsmSigner(ctx context.Context, testDir string, serial uint32) (*keys
 	cryptoPub, _ := signer.PublicKey()
 	pub := cryptoPub.(*ecdsa.PublicKey)
 
-	pk, err := keys.EcdsaTufKey(pub, true)
+	pk, err := keys.EcdsaTufKey(pub, app.DeprecatedEcdsaFormat)
 	if err != nil {
 		return nil, err
 	}
@@ -161,7 +161,7 @@ func CreateTestHsmSigner(testDir string, root *x509.Certificate, rootSigner cryp
 		return nil, err
 	}
 
-	pk, err := keys.EcdsaTufKey(pub, true)
+	pk, err := keys.EcdsaTufKey(pub, app.DeprecatedEcdsaFormat)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
PART 2 OF HEX TO ECDSA MIGRATION. See https://github.com/sigstore/root-signing/issues/329#issuecomment-1243792015

* Update HSM and online key parsing logic to allow for parsing into hex and parsing into PEM.
* Cleans up some code that can use sigstore/sigstore cryptoutil parsing
* Tested that getting signing key from HSM and online can be done with both hex and PEM and go-tuf can verify either.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->