### PR TITLE
feat: parameterize deprecated key formats in init and add testing (part 3/4)

### DIFF
--- a/cmd/tuf/app/add-key.go
+++ b/cmd/tuf/app/add-key.go
@@ -29,9 +29,7 @@ import (
 
 	"github.com/peterbourgon/ff/v3/ffcli"
 	"github.com/sigstore/cosign/cmd/cosign/cli/pivcli"
-	"github.com/sigstore/root-signing/pkg/keys"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
-	"github.com/theupdateframework/go-tuf/data"
 	"golang.org/x/term"
 )
 
@@ -63,7 +61,7 @@ func AddKey() *ffcli.Command {
 
 type KeyAndAttestations struct {
 	Attestations pivcli.Attestations
-	Key          *data.PublicKey
+	Key          *ecdsa.PublicKey
 }
 
 func GetKeyAndAttestation(ctx context.Context) (*KeyAndAttestations, error) {
@@ -73,12 +71,8 @@ func GetKeyAndAttestation(ctx context.Context) (*KeyAndAttestations, error) {
 	}
 
 	pub := attestations.KeyCert.PublicKey.(*ecdsa.PublicKey)
-	pk, err := keys.EcdsaTufKey(pub, true)
-	if err != nil {
-		return nil, err
-	}
 
-	return &KeyAndAttestations{Attestations: *attestations, Key: pk}, nil
+	return &KeyAndAttestations{Attestations: *attestations, Key: pub}, nil
 }
 
 func AddKeyCmd(ctx context.Context, directory string) error {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -126,7 +126,8 @@ func createTestAttestations(root *x509.Certificate, rootSigner crypto.PrivateKey
 	return deviceCert, keyCert, nil
 }
 
-func GetTestHsmSigner(ctx context.Context, testDir string, serial uint32) (*keys.SignerAndTufKey, error) {
+func GetTestHsmSigner(ctx context.Context, testDir string, serial uint32,
+	deprecatedKeyFormat bool) (*keys.SignerAndTufKey, error) {
 	// read private key from file.
 	serialStr := fmt.Sprint(serial)
 	privKeyFile := filepath.Join(testDir, "keys", serialStr, serialStr+"_privkey.pem")
@@ -139,7 +140,7 @@ func GetTestHsmSigner(ctx context.Context, testDir string, serial uint32) (*keys
 	cryptoPub, _ := signer.PublicKey()
 	pub := cryptoPub.(*ecdsa.PublicKey)
 
-	pk, err := keys.EcdsaTufKey(pub, app.DeprecatedEcdsaFormat)
+	pk, err := keys.EcdsaTufKey(pub, deprecatedKeyFormat)
 	if err != nil {
 		return nil, err
 	}
@@ -161,11 +162,6 @@ func CreateTestHsmSigner(testDir string, root *x509.Certificate, rootSigner cryp
 		return nil, err
 	}
 
-	pk, err := keys.EcdsaTufKey(pub, app.DeprecatedEcdsaFormat)
-	if err != nil {
-		return nil, err
-	}
-
 	deviceCertPem, err := cryptoutils.MarshalCertificateToPEM(deviceCert)
 	if err != nil {
 		return nil, err
@@ -176,7 +172,7 @@ func CreateTestHsmSigner(testDir string, root *x509.Certificate, rootSigner cryp
 	}
 
 	keyAndAttestations := &app.KeyAndAttestations{
-		Key: pk,
+		Key: pub,
 		Attestations: pivcli.Attestations{
 			DeviceCert:    deviceCert,
 			DeviceCertPem: string(deviceCertPem),


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

PART 3 OF https://github.com/sigstore/root-signing/issues/329#issuecomment-1243792015

I know this makes a lot of changes in the summary, but they are all fairly minor.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
* feat: Add parameter to `InitCmd` to use deprecated key formats when adding HSM/online keys
* fix: Fixes bug in `InitCmd` that adds pre-entries for `allRootKeys` (old + new) to `targets` role instead of `root`. E2E testing verifies this.
* cleanup: `KeyAndAttestations` only requires the ecdsa public key, format agnostic.
* fix: Fixes bug (?) where we store canonical JSON in the metadata store. We don't need this, and it breaks with the PEM newlines.
* feat: Explicit error when we `SignCmd` but no signature was added to the metadata, useful for catching if we sign with PEM and do not expect PEM keys.
* feat: Factors out the `verify` CLI command and uses it in e2e testing.
* test: Extensive testing for verifying the migration process. Start with a root with deprecated format, and then flip the deprecated format bool and expect a key migration.

We still have a TODO to make the `SignCmd` CLI command allow multiple key IDs for the same sig. Awaiting part 4.

Added TODO for also unit testing the pre-entries logic. It is fragile and worth testing.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->