### PR TITLE
fix: properly update snapshot and timestamp keys

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -182,6 +182,7 @@ require (
 	go.uber.org/multierr v1.8.0 // indirect
 	go.uber.org/zap v1.22.0 // indirect
 	golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90 // indirect
+	golang.org/x/exp v0.0.0-20220916125017-b168a2c6b86b
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
 	golang.org/x/net v0.0.0-20220826154423-83b083e8dc8b // indirect
 	golang.org/x/oauth2 v0.0.0-20220822191816-0ebed06d0094 // indirect
@@ -189,7 +190,7 @@ require (
 	golang.org/x/sys v0.0.0-20220909162455-aba9fc2a8ff2 // indirect
 	golang.org/x/text v0.3.8-0.20211004125949-5bd84dd9b33b // indirect
 	golang.org/x/time v0.0.0-20220722155302-e5dcc9cfc0b9 // indirect
-	golang.org/x/tools v0.1.11 // indirect
+	golang.org/x/tools v0.1.12 // indirect
 	google.golang.org/api v0.95.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20220805133916-01dd62135a58 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1590,6 +1590,8 @@ golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
 golang.org/x/exp v0.0.0-20200331195152-e8c3332aa8e5/go.mod h1:4M0jN8W1tt0AVLNr8HDosyJCDCDuyL9N9+3m7wDWgKw=
+golang.org/x/exp v0.0.0-20220916125017-b168a2c6b86b h1:SCE/18RnFsLrjydh/R/s5EVvHoZprqEQUuoxK8q2Pc4=
+golang.org/x/exp v0.0.0-20220916125017-b168a2c6b86b/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -2007,6 +2009,7 @@ golang.org/x/tools v0.1.7/go.mod h1:LGqMHiF4EqQNHR1JncWGqT5BVaXmza+X+BDGol+dOxo=
 golang.org/x/tools v0.1.10/go.mod h1:Uh6Zz+xoGYZom868N8YTex3t7RhtHDBrE8Gzo9bV56E=
 golang.org/x/tools v0.1.11 h1:loJ25fNOEhSXfHrpoGj91eCUThwdNX6u24rO1xnNteY=
 golang.org/x/tools v0.1.11/go.mod h1:SgwaegtQh8clINPpECJMqnxLv9I09HLqnW3RMqW0CA4=
+golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -19,11 +19,8 @@
 package test
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
-	"io"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -34,65 +31,20 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/secure-systems-lab/go-securesystemslib/cjson"
-	"github.com/sigstore/cosign/pkg/cosign"
-	csignature "github.com/sigstore/cosign/pkg/signature"
 	"github.com/sigstore/root-signing/cmd/tuf/app"
 	vapp "github.com/sigstore/root-signing/cmd/verify/app"
 	"github.com/sigstore/root-signing/pkg/keys"
 	prepo "github.com/sigstore/root-signing/pkg/repo"
 	stuf "github.com/sigstore/sigstore/pkg/tuf"
+	tufkeys "github.com/theupdateframework/go-tuf/pkg/keys"
 
 	"github.com/theupdateframework/go-tuf"
 	"github.com/theupdateframework/go-tuf/client"
 	"github.com/theupdateframework/go-tuf/data"
-	tufkeys "github.com/theupdateframework/go-tuf/pkg/keys"
 )
 
 // TODO(asraa): Add more unit tests, including
 //   * Custom metadata included in targets
-
-// Create a test HSM key located in a keys/ subdirectory of testDir.
-func createTestHsmKey(testDir string) error {
-	keyDir := filepath.Join(testDir, "keys", "10550341")
-	if err := os.MkdirAll(keyDir, 0755); err != nil {
-		return err
-	}
-
-	testKey := "test_data/10550341"
-	wd, _ := os.Getwd()
-	testKey = filepath.Join(wd, testKey)
-
-	return filepath.Walk(testKey, func(path string, info os.FileInfo, err error) error {
-		var relPath string = strings.Replace(path, testKey, "", 1)
-		if relPath == "" {
-			return nil
-		}
-		if info.IsDir() {
-			return os.Mkdir(filepath.Join(keyDir, relPath), 0755)
-		} else {
-			var data, err1 = ioutil.ReadFile(filepath.Join(testKey, relPath))
-			if err1 != nil {
-				return err1
-			}
-			return ioutil.WriteFile(filepath.Join(keyDir, relPath), data, 0777)
-		}
-	})
-}
-
-// Create fake key signer in testDirectory. Returns file reference to signer.
-func createTestSigner(t *testing.T) string {
-	keys, err := cosign.GenerateKeyPair(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	temp := t.TempDir()
-	f, _ := os.CreateTemp(temp, "*.key")
-
-	if _, err := io.Copy(f, bytes.NewBuffer(keys.PrivateBytes)); err != nil {
-		t.Fatal(err)
-	}
-	return f.Name()
-}
 
 // Verify with the go-tuf client, sigstore-tuf, and our CLI verification.
 // Note! Sigstore TUF uses a singleton to cache network calls. Disable this
@@ -194,120 +146,59 @@ func verifySigstoreTuf(t *testing.T, repo string, root []byte,
 	return nil
 }
 
-func snapshotTimestampPublish(ctx context.Context, t *testing.T, repo string,
-	snapshotKey, timestampKey string, deprecated bool) {
-	if err := app.SnapshotCmd(ctx, repo); err != nil {
-		t.Fatalf("expected Snapshot command to pass, got err: %s", err)
-	}
-	snapshotSigner, err := csignature.SignerVerifierFromKeyRef(ctx, snapshotKey, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := app.SignCmd(ctx, repo, []string{"snapshot"}, snapshotSigner, deprecated); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := app.TimestampCmd(ctx, repo); err != nil {
-		t.Fatalf("expected Timestamp command to pass, got err: %s", err)
-	}
-	timestampSigner, err := csignature.SignerVerifierFromKeyRef(ctx, timestampKey, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := app.SignCmd(ctx, repo, []string{"timestamp"}, timestampSigner, deprecated); err != nil {
-		t.Fatal(err)
-	}
-
-	// Successful Publishing!
-	if err := app.PublishCmd(ctx, repo); err != nil {
-		t.Fatal(err)
-	}
-}
-
 func TestInitCmd(t *testing.T) {
 	ctx := context.Background()
-	td := t.TempDir()
+	stack := newRepoTestStack(ctx, t)
 
-	testTarget := filepath.Join(td, "foo.txt")
-	targetsConfig := map[string]json.RawMessage{testTarget: nil}
+	stack.addTarget(t, "foo.txt", "abc", nil)
+	stack.genKey(t, true)
 
-	if err := os.WriteFile(testTarget, []byte("abc"), 0600); err != nil {
+	if _, err := CreateTestHsmSigner(stack.repoDir, stack.hsmRootCA, stack.hsmRootSigner); err != nil {
 		t.Fatal(err)
 	}
-
-	if err := createTestHsmKey(td); err != nil {
-		t.Fatal(err)
-	}
-
-	snapshotKey := createTestSigner(t)
-	timestampKey := createTestSigner(t)
 
 	// Initialize succeeds.
-	if err := app.InitCmd(ctx, td, "", 1, targetsConfig, snapshotKey, timestampKey, app.DeprecatedEcdsaFormat); err != nil {
+	if err := app.InitCmd(ctx, stack.repoDir, "", 1,
+		stack.targetsConfig, stack.snapshotRef, stack.timestampRef,
+		app.DeprecatedEcdsaFormat); err != nil {
 		t.Fatal(err)
 	}
 
 	// Verify that root and targets have expected version 1 on Init.
-	checkMetadataVersion(t, td,
+	checkMetadataVersion(t, stack.repoDir,
 		[]string{"root.json", "targets.json"},
 		1)
 }
 
 func TestSignRootTargets(t *testing.T) {
 	// Initialize.
-
 	ctx := context.Background()
-	td := t.TempDir()
-
-	rootCA, rootSigner, err := CreateRootCA()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	testTarget := filepath.Join(td, "foo.txt")
-	targetsConfig := map[string]json.RawMessage{testTarget: nil}
-
-	if err := os.WriteFile(testTarget, []byte("abc"), 0600); err != nil {
-		t.Fatal(err)
-	}
-
-	serial, err := CreateTestHsmSigner(td, rootCA, rootSigner)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	snapshotKey := createTestSigner(t)
-	timestampKey := createTestSigner(t)
+	stack := newRepoTestStack(ctx, t)
+	stack.addTarget(t, "foo.txt", "abc", nil)
+	rootKeyRef := stack.genKey(t, true)
 
 	// Initialize with 1 succeeds.
-	if err := app.InitCmd(ctx, td, "", 1, targetsConfig, snapshotKey, timestampKey, app.DeprecatedEcdsaFormat); err != nil {
+	if err := app.InitCmd(ctx, stack.repoDir, "", 1,
+		stack.targetsConfig, stack.snapshotRef, stack.timestampRef,
+		app.DeprecatedEcdsaFormat); err != nil {
 		t.Fatal(err)
 	}
 
 	// Sign root and targets.
-	signer, err := GetTestHsmSigner(ctx, td, *serial)
-	if err != nil {
+	rootSigner := stack.getSigner(t, rootKeyRef)
+	if err := app.SignCmd(ctx, stack.repoDir, []string{"root", "targets"},
+		rootSigner, app.DeprecatedEcdsaFormat); err != nil {
 		t.Fatal(err)
 	}
-	if err := app.SignCmd(ctx, td, []string{"root", "targets"}, signer, app.DeprecatedEcdsaFormat); err != nil {
-		t.Fatal(err)
-	}
-	pubKey, err := keys.ConstructTufKey(ctx, signer, app.DeprecatedEcdsaFormat)
+
+	pubKey, err := keys.ConstructTufKey(ctx, rootSigner, app.DeprecatedEcdsaFormat)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Verify that root and targets have one signature.
-	store := tuf.FileSystemStore(td, nil)
-	meta, err := store.GetMeta()
-	if err != nil {
-		t.Fatal(err)
-	}
 	for _, metaName := range []string{"root.json", "targets.json"} {
-		md, ok := meta[metaName]
-		if !ok {
-			t.Fatalf("missing %s", metaName)
-		}
+		md := stack.getManifest(t, metaName)
 		signed := &data.Signed{}
 		if err := json.Unmarshal(md, signed); err != nil {
 			t.Fatal(err)
@@ -326,54 +217,27 @@ func TestSignRootTargets(t *testing.T) {
 
 func TestSnapshotUnvalidatedFails(t *testing.T) {
 	ctx := context.Background()
-	td := t.TempDir()
+	stack := newRepoTestStack(ctx, t)
+	stack.addTarget(t, "foo.txt", "abc", nil)
+	rootKeyRef := stack.genKey(t, true)
+	_ = stack.genKey(t, true)
 
-	rootCA, rootSigner, err := CreateRootCA()
-	if err != nil {
+	// Initialize with threshold 1 succeeds.
+	if err := app.InitCmd(ctx, stack.repoDir, "", 1,
+		stack.targetsConfig, stack.snapshotRef, stack.timestampRef,
+		app.DeprecatedEcdsaFormat); err != nil {
 		t.Fatal(err)
 	}
 
-	testTarget := filepath.Join(td, "foo.txt")
-	targetsConfig := map[string]json.RawMessage{testTarget: nil}
-
-	if err := os.WriteFile(testTarget, []byte("abc"), 0600); err != nil {
-		t.Fatal(err)
-	}
-
-	rootkey1, err := CreateTestHsmSigner(td, rootCA, rootSigner)
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, err = CreateTestHsmSigner(td, rootCA, rootSigner)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	snapshotKey := createTestSigner(t)
-	timestampKey := createTestSigner(t)
-
-	// Initialize succeeds.
-	if err := app.InitCmd(ctx, td, "", 1, targetsConfig, snapshotKey, timestampKey, app.DeprecatedEcdsaFormat); err != nil {
-		t.Fatal(err)
-	}
-
-	// Validate that root and targets have one unfilled signature.
-	store := tuf.FileSystemStore(td, nil)
-	meta, err := store.GetMeta()
-	if err != nil {
-		t.Fatal(err)
-	}
+	// Validate that root and targets have two unfilled signature.
 	for _, metaName := range []string{"root.json", "targets.json"} {
-		md, ok := meta[metaName]
-		if !ok {
-			t.Fatalf("missing %s", metaName)
-		}
+		md := stack.getManifest(t, metaName)
 		signed := &data.Signed{}
 		if err := json.Unmarshal(md, signed); err != nil {
 			t.Fatal(err)
 		}
 		if len(signed.Signatures) != 2 {
-			t.Fatalf("expected 1 signature on %s", metaName)
+			t.Fatalf("expected 2 signature on %s", metaName)
 		}
 		if len(signed.Signatures[0].Signature) != 0 {
 			t.Fatalf("expected empty signature for key ID %s", signed.Signatures[0].KeyID)
@@ -381,30 +245,20 @@ func TestSnapshotUnvalidatedFails(t *testing.T) {
 	}
 
 	// Try to snapshot. Expect to fail.
-	if err := app.SnapshotCmd(ctx, td); err == nil {
+	if err := app.SnapshotCmd(ctx, stack.repoDir); err == nil {
 		t.Fatalf("expected Snapshot command to fail")
 	}
 
 	// Now sign root and targets with 1/1 threshold key.
-	signer, err := GetTestHsmSigner(ctx, td, *rootkey1)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := app.SignCmd(ctx, td, []string{"root", "targets"}, signer, app.DeprecatedEcdsaFormat); err != nil {
+	rootSigner := stack.getSigner(t, rootKeyRef)
+	if err := app.SignCmd(ctx, stack.repoDir, []string{"root", "targets"},
+		rootSigner, app.DeprecatedEcdsaFormat); err != nil {
 		t.Fatal(err)
 	}
 
 	// Expect that there is still one empty placeholder signature.
-	store = tuf.FileSystemStore(td, nil)
-	meta, err = store.GetMeta()
-	if err != nil {
-		t.Fatal(err)
-	}
 	for _, metaName := range []string{"root.json", "targets.json"} {
-		md, ok := meta[metaName]
-		if !ok {
-			t.Fatalf("missing %s", metaName)
-		}
+		md := stack.getManifest(t, metaName)
 		signed := &data.Signed{}
 		if err := json.Unmarshal(md, signed); err != nil {
 			t.Fatal(err)
@@ -418,63 +272,48 @@ func TestSnapshotUnvalidatedFails(t *testing.T) {
 	}
 
 	// Snapshot success! We clear the empty placeholder signature in root/targets.
-	if err := app.SnapshotCmd(ctx, td); err != nil {
-		t.Fatalf("expected Snapshot command to pass, got err: %s", err)
+	stack.snapshot(t, app.DeprecatedEcdsaFormat)
+	for _, metaName := range []string{"root.json", "targets.json"} {
+		md := stack.getManifest(t, metaName)
+		signed := &data.Signed{}
+		if err := json.Unmarshal(md, signed); err != nil {
+			t.Fatal(err)
+		}
+		if len(signed.Signatures) != 1 {
+			t.Fatalf("expected 1 signature on %s, got %d", metaName, len(signed.Signatures))
+		}
 	}
 }
 
 func TestPublishSuccess(t *testing.T) {
+	// Initialize.
 	ctx := context.Background()
-	td := t.TempDir()
+	stack := newRepoTestStack(ctx, t)
+	stack.addTarget(t, "foo.txt", "abc", nil)
+	rootKeyRef := stack.genKey(t, true)
 
-	rootCA, rootSigner, err := CreateRootCA()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	testTarget := filepath.Join(td, "foo.txt")
-	targetsConfig := map[string]json.RawMessage{testTarget: nil}
-
-	if err := os.WriteFile(testTarget, []byte("abc"), 0600); err != nil {
-		t.Fatal(err)
-	}
-
-	rootSerial, err := CreateTestHsmSigner(td, rootCA, rootSigner)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	snapshotKey := createTestSigner(t)
-	timestampKey := createTestSigner(t)
-
-	// Initialize succeeds.
-	if err := app.InitCmd(ctx, td, "", 1, targetsConfig, snapshotKey, timestampKey, app.DeprecatedEcdsaFormat); err != nil {
+	// Initialize with 1 succeeds.
+	if err := app.InitCmd(ctx, stack.repoDir, "", 1,
+		stack.targetsConfig, stack.snapshotRef, stack.timestampRef,
+		app.DeprecatedEcdsaFormat); err != nil {
 		t.Fatal(err)
 	}
 
 	// Sign root & targets
-	rootKey, err := GetTestHsmSigner(ctx, td, *rootSerial)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := app.SignCmd(ctx, td, []string{"root", "targets"}, rootKey, app.DeprecatedEcdsaFormat); err != nil {
+	rootSigner := stack.getSigner(t, rootKeyRef)
+	if err := app.SignCmd(ctx, stack.repoDir, []string{"root", "targets"},
+		rootSigner, app.DeprecatedEcdsaFormat); err != nil {
 		t.Fatal(err)
 	}
 
 	// Sign snapshot and timestamp
-	snapshotTimestampPublish(ctx, t, td, snapshotKey, timestampKey, app.DeprecatedEcdsaFormat)
+	stack.snapshot(t, app.DeprecatedEcdsaFormat)
+	stack.timestamp(t, app.DeprecatedEcdsaFormat)
+	stack.publish(t)
 
 	// Check versions.
-	store := tuf.FileSystemStore(td, nil)
-	meta, err := store.GetMeta()
-	if err != nil {
-		t.Fatal(err)
-	}
 	for _, metaName := range []string{"root.json", "targets.json", "snapshot.json", "timestamp.json"} {
-		md, ok := meta[metaName]
-		if !ok {
-			t.Fatalf("missing %s", metaName)
-		}
+		md := stack.getManifest(t, metaName)
 		signed := &data.Signed{}
 		if err := json.Unmarshal(md, signed); err != nil {
 			t.Fatal(err)
@@ -489,7 +328,7 @@ func TestPublishSuccess(t *testing.T) {
 	}
 
 	// Verify with go-tuf
-	targetFiles, err := verifyTuf(t, td, meta["root.json"])
+	targetFiles, err := verifyTuf(t, stack.repoDir, stack.getManifest(t, "root.json"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -507,55 +346,36 @@ func TestRotateRootKey(t *testing.T) {
 	// This tests root key rotation: we use a threshold of 1 with 2 root keys
 	// and expect to rotate one keyholder during an update.
 	ctx := context.Background()
-	td := t.TempDir()
+	stack := newRepoTestStack(ctx, t)
+	stack.addTarget(t, "foo.txt", "abc", nil)
+	rootKeyRef1 := stack.genKey(t, true)
+	rootKeyRef2 := stack.genKey(t, true)
 
-	rootCA, rootSigner, err := CreateRootCA()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	testTarget := filepath.Join(td, "foo.txt")
-	targetsConfig := map[string]json.RawMessage{testTarget: nil}
-
-	if err := os.WriteFile(testTarget, []byte("abc"), 0600); err != nil {
-		t.Fatal(err)
-	}
-
-	rootSerial1, err := CreateTestHsmSigner(td, rootCA, rootSigner)
-	if err != nil {
-		t.Fatal(err)
-	}
-	rootSerial2, err := CreateTestHsmSigner(td, rootCA, rootSigner)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	snapshotKey := createTestSigner(t)
-	timestampKey := createTestSigner(t)
-
-	// Initialize succeeds.
-	if err := app.InitCmd(ctx, td, "", 1, targetsConfig, snapshotKey, timestampKey, app.DeprecatedEcdsaFormat); err != nil {
+	// Initialize succeeds
+	if err := app.InitCmd(ctx, stack.repoDir, "", 1,
+		stack.targetsConfig, stack.snapshotRef, stack.timestampRef,
+		app.DeprecatedEcdsaFormat); err != nil {
 		t.Fatal(err)
 	}
 
 	// Sign root & targets with key 1
-	rootKey1, err := GetTestHsmSigner(ctx, td, *rootSerial1)
-	if err != nil {
+	rootSigner1 := stack.getSigner(t, rootKeyRef1)
+	if err := app.SignCmd(ctx, stack.repoDir, []string{"root", "targets"},
+		rootSigner1, app.DeprecatedEcdsaFormat); err != nil {
 		t.Fatal(err)
 	}
-	rootTufKey1, err := keys.ConstructTufKey(ctx, rootKey1, app.DeprecatedEcdsaFormat)
+	rootTufKey1, err := keys.ConstructTufKey(ctx, rootSigner1, app.DeprecatedEcdsaFormat)
 	if err != nil {
-		t.Fatal(err)
-	}
-	if err := app.SignCmd(ctx, td, []string{"root", "targets"}, rootKey1, app.DeprecatedEcdsaFormat); err != nil {
 		t.Fatal(err)
 	}
 
 	// Sign snapshot and timestamp
-	snapshotTimestampPublish(ctx, t, td, snapshotKey, timestampKey, app.DeprecatedEcdsaFormat)
+	stack.snapshot(t, app.DeprecatedEcdsaFormat)
+	stack.timestamp(t, app.DeprecatedEcdsaFormat)
+	stack.publish(t)
 
 	// Check that there are two root key signers: key 1 and key 2.
-	store := tuf.FileSystemStore(td, nil)
+	store := tuf.FileSystemStore(stack.repoDir, nil)
 	root, err := prepo.GetRootFromStore(store)
 	if err != nil {
 		t.Fatal(err)
@@ -564,11 +384,8 @@ func TestRotateRootKey(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected root role")
 	}
-	rootKey2, err := GetTestHsmSigner(ctx, td, *rootSerial2)
-	if err != nil {
-		t.Fatal(err)
-	}
-	rootTufKey2, err := keys.ConstructTufKey(ctx, rootKey2, app.DeprecatedEcdsaFormat)
+	rootSigner2 := stack.getSigner(t, rootKeyRef2)
+	rootTufKey2, err := keys.ConstructTufKey(ctx, rootSigner2, app.DeprecatedEcdsaFormat)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -581,16 +398,13 @@ func TestRotateRootKey(t *testing.T) {
 	}
 
 	// Now remove the second key and add a third key.
-	if err := os.RemoveAll(filepath.Join(td, "keys", fmt.Sprint(*rootSerial2))); err != nil {
-		t.Fatal(err)
-	}
-	rootSerial3, err := CreateTestHsmSigner(td, rootCA, rootSigner)
-	if err != nil {
-		t.Fatal(err)
-	}
+	stack.removeHsmKey(t, rootKeyRef2)
+	rootKeyRef3 := stack.genKey(t, true)
 
 	// Create a new root.
-	if err := app.InitCmd(ctx, td, td, 1, targetsConfig, snapshotKey, timestampKey, app.DeprecatedEcdsaFormat); err != nil {
+	if err := app.InitCmd(ctx, stack.repoDir, stack.repoDir, 1,
+		stack.targetsConfig, stack.snapshotRef, stack.timestampRef,
+		app.DeprecatedEcdsaFormat); err != nil {
 		t.Fatal(err)
 	}
 
@@ -603,11 +417,8 @@ func TestRotateRootKey(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected root role")
 	}
-	rootKey3, err := GetTestHsmSigner(ctx, td, *rootSerial3)
-	if err != nil {
-		t.Fatal(err)
-	}
-	rootTufKey3, err := keys.ConstructTufKey(ctx, rootKey3, app.DeprecatedEcdsaFormat)
+	rootSigner3 := stack.getSigner(t, rootKeyRef3)
+	rootTufKey3, err := keys.ConstructTufKey(ctx, rootSigner3, app.DeprecatedEcdsaFormat)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -625,82 +436,54 @@ func TestRotateRootKey(t *testing.T) {
 	}
 
 	// Sign root & targets
-	rootKey, err := GetTestHsmSigner(ctx, td, *rootSerial1)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := app.SignCmd(ctx, td, []string{"root", "targets"}, rootKey, app.DeprecatedEcdsaFormat); err != nil {
+	if err := app.SignCmd(ctx, stack.repoDir, []string{"root", "targets"}, rootSigner1, app.DeprecatedEcdsaFormat); err != nil {
 		t.Fatal(err)
 	}
 
 	// Sign snapshot and timestamp
-	snapshotTimestampPublish(ctx, t, td, snapshotKey, timestampKey, app.DeprecatedEcdsaFormat)
+	stack.snapshot(t, app.DeprecatedEcdsaFormat)
+	stack.timestamp(t, app.DeprecatedEcdsaFormat)
+	stack.publish(t)
 
 	// Verify with go-tuf
-	meta, err := store.GetMeta()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if _, err = verifyTuf(t, td, meta["root.json"]); err != nil {
+	if _, err = verifyTuf(t, stack.repoDir, stack.getManifest(t, "root.json")); err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestRotateTarget(t *testing.T) {
+	// Initialize.
 	ctx := context.Background()
-	td := t.TempDir()
-
-	rootCA, rootSigner, err := CreateRootCA()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	testTarget := filepath.Join(td, "foo.txt")
-	targetsConfig := map[string]json.RawMessage{testTarget: nil}
-
-	if err := os.WriteFile(testTarget, []byte("abc"), 0600); err != nil {
-		t.Fatal(err)
-	}
-
-	rootSerial, err := CreateTestHsmSigner(td, rootCA, rootSigner)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	snapshotKey := createTestSigner(t)
-	timestampKey := createTestSigner(t)
+	stack := newRepoTestStack(ctx, t)
+	stack.addTarget(t, "foo.txt", "abc", nil)
+	rootKeyRef := stack.genKey(t, true)
 
 	// Initialize succeeds.
-	if err := app.InitCmd(ctx, td, "", 1, targetsConfig, snapshotKey, timestampKey, app.DeprecatedEcdsaFormat); err != nil {
+	if err := app.InitCmd(ctx, stack.repoDir, "", 1,
+		stack.targetsConfig, stack.snapshotRef, stack.timestampRef,
+		app.DeprecatedEcdsaFormat); err != nil {
 		t.Fatal(err)
 	}
 
 	// Sign root & targets
-	rootKey, err := GetTestHsmSigner(ctx, td, *rootSerial)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := app.SignCmd(ctx, td, []string{"root", "targets"}, rootKey, app.DeprecatedEcdsaFormat); err != nil {
+	rootSigner := stack.getSigner(t, rootKeyRef)
+	if err := app.SignCmd(ctx, stack.repoDir, []string{"root", "targets"},
+		rootSigner, app.DeprecatedEcdsaFormat); err != nil {
 		t.Fatal(err)
 	}
 
 	// Sign snapshot and timestamp
-	snapshotTimestampPublish(ctx, t, td, snapshotKey, timestampKey, app.DeprecatedEcdsaFormat)
+	stack.snapshot(t, app.DeprecatedEcdsaFormat)
+	stack.timestamp(t, app.DeprecatedEcdsaFormat)
+	stack.publish(t)
 
 	// Check versions.
-	checkMetadataVersion(t, td,
+	checkMetadataVersion(t, stack.repoDir,
 		[]string{"root.json", "targets.json", "snapshot.json", "timestamp.json"},
 		1)
 
 	// Verify with go-tuf
-	store := tuf.FileSystemStore(td, nil)
-	meta, err := store.GetMeta()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Verify with go-tuf
-	targetFiles, err := verifyTuf(t, td, meta["root.json"])
+	targetFiles, err := verifyTuf(t, stack.repoDir, stack.getManifest(t, "root.json"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -714,39 +497,34 @@ func TestRotateTarget(t *testing.T) {
 	}
 
 	// New target, config only targets new file, not old
-	testTarget = filepath.Join(td, "bar.txt")
-	targetsConfig = map[string]json.RawMessage{testTarget: nil}
-
-	if err := os.WriteFile(testTarget, []byte("abcdef"), 0600); err != nil {
-		t.Fatal(err)
-	}
+	stack.removeTarget(t, "foo.txt")
+	stack.addTarget(t, "bar.txt", "abcdef", nil)
 
 	// Initialize succeeds.
-	if err := app.InitCmd(ctx, td, td, 1, targetsConfig, snapshotKey, timestampKey, app.DeprecatedEcdsaFormat); err != nil {
+	if err := app.InitCmd(ctx, stack.repoDir, stack.repoDir, 1,
+		stack.targetsConfig, stack.snapshotRef, stack.timestampRef,
+		app.DeprecatedEcdsaFormat); err != nil {
 		t.Fatal(err)
 	}
 
 	// Sign root & targets
-	if err := app.SignCmd(ctx, td, []string{"root", "targets"}, rootKey, app.DeprecatedEcdsaFormat); err != nil {
+	if err := app.SignCmd(ctx, stack.repoDir, []string{"root", "targets"},
+		rootSigner, app.DeprecatedEcdsaFormat); err != nil {
 		t.Fatal(err)
 	}
 
 	// Sign snapshot and timestamp
-	snapshotTimestampPublish(ctx, t, td, snapshotKey, timestampKey, app.DeprecatedEcdsaFormat)
+	stack.snapshot(t, app.DeprecatedEcdsaFormat)
+	stack.timestamp(t, app.DeprecatedEcdsaFormat)
+	stack.publish(t)
 
 	// Check versions.
-	checkMetadataVersion(t, td,
+	checkMetadataVersion(t, stack.repoDir,
 		[]string{"root.json", "targets.json", "snapshot.json", "timestamp.json"},
 		2)
 
 	// Verify with go-tuf
-	meta, err = store.GetMeta()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Verify with go-tuf
-	targetFiles, err = verifyTuf(t, td, meta["root.json"])
+	targetFiles, err = verifyTuf(t, stack.repoDir, stack.getManifest(t, "root.json"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -762,59 +540,39 @@ func TestRotateTarget(t *testing.T) {
 
 // Tests that enabling consistent snapshots at version > 1 works.
 func TestConsistentSnapshotFlip(t *testing.T) {
+	// Initialize.
 	ctx := context.Background()
-	td := t.TempDir()
-
-	rootCA, rootSigner, err := CreateRootCA()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	testTarget := filepath.Join(td, "foo.txt")
-	targetsConfig := map[string]json.RawMessage{testTarget: nil}
-
-	if err := os.WriteFile(testTarget, []byte("abc"), 0600); err != nil {
-		t.Fatal(err)
-	}
-
-	rootSerial, err := CreateTestHsmSigner(td, rootCA, rootSigner)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	snapshotKey := createTestSigner(t)
-	timestampKey := createTestSigner(t)
+	stack := newRepoTestStack(ctx, t)
+	stack.addTarget(t, "foo.txt", "abc", nil)
+	rootKeyRef := stack.genKey(t, true)
 
 	// Initialize succeeds with consistent snapshot off.
 	app.ConsistentSnapshot = false
-	if err := app.InitCmd(ctx, td, "", 1, targetsConfig, snapshotKey, timestampKey, app.DeprecatedEcdsaFormat); err != nil {
+	if err := app.InitCmd(ctx, stack.repoDir, "", 1,
+		stack.targetsConfig, stack.snapshotRef, stack.timestampRef,
+		app.DeprecatedEcdsaFormat); err != nil {
 		t.Fatal(err)
 	}
 
 	// Sign root & targets
-	rootKey, err := GetTestHsmSigner(ctx, td, *rootSerial)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := app.SignCmd(ctx, td, []string{"root", "targets"}, rootKey, app.DeprecatedEcdsaFormat); err != nil {
+	rootSigner := stack.getSigner(t, rootKeyRef)
+	if err := app.SignCmd(ctx, stack.repoDir, []string{"root", "targets"},
+		rootSigner, app.DeprecatedEcdsaFormat); err != nil {
 		t.Fatal(err)
 	}
 
 	// Sign snapshot and timestamp
-	snapshotTimestampPublish(ctx, t, td, snapshotKey, timestampKey, app.DeprecatedEcdsaFormat)
+	stack.snapshot(t, app.DeprecatedEcdsaFormat)
+	stack.timestamp(t, app.DeprecatedEcdsaFormat)
+	stack.publish(t)
 
 	// Check versions.
-	checkMetadataVersion(t, td,
+	checkMetadataVersion(t, stack.repoDir,
 		[]string{"root.json", "targets.json", "snapshot.json", "timestamp.json"},
 		1)
 
 	// Verify with go-tuf
-	store := tuf.FileSystemStore(td, nil)
-	meta, err := store.GetMeta()
-	if err != nil {
-		t.Fatal(err)
-	}
-	targetFiles, err := verifyTuf(t, td, meta["root.json"])
+	targetFiles, err := verifyTuf(t, stack.repoDir, stack.getManifest(t, "root.json"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -830,25 +588,29 @@ func TestConsistentSnapshotFlip(t *testing.T) {
 	// Flip consistent snapshot on.
 	app.ConsistentSnapshot = true
 	// Initialize succeeds.
-	if err := app.InitCmd(ctx, td, td, 1, targetsConfig, snapshotKey, timestampKey, app.DeprecatedEcdsaFormat); err != nil {
+	if err := app.InitCmd(ctx, stack.repoDir, stack.repoDir, 1,
+		stack.targetsConfig, stack.snapshotRef, stack.timestampRef,
+		app.DeprecatedEcdsaFormat); err != nil {
 		t.Fatal(err)
 	}
 
 	// Sign root & targets
-	if err := app.SignCmd(ctx, td, []string{"root", "targets"}, rootKey, app.DeprecatedEcdsaFormat); err != nil {
+	if err := app.SignCmd(ctx, stack.repoDir, []string{"root", "targets"},
+		rootSigner, app.DeprecatedEcdsaFormat); err != nil {
 		t.Fatal(err)
 	}
-
 	// Sign snapshot and timestamp
-	snapshotTimestampPublish(ctx, t, td, snapshotKey, timestampKey, app.DeprecatedEcdsaFormat)
+	stack.snapshot(t, app.DeprecatedEcdsaFormat)
+	stack.timestamp(t, app.DeprecatedEcdsaFormat)
+	stack.publish(t)
 
 	// Check versions.
-	checkMetadataVersion(t, td,
+	checkMetadataVersion(t, stack.repoDir,
 		[]string{"root.json", "targets.json", "snapshot.json", "timestamp.json"},
 		2)
 
 	// Verify with TUF
-	targetFiles, err = verifyTuf(t, td, meta["root.json"])
+	targetFiles, err = verifyTuf(t, stack.repoDir, stack.getManifest(t, "root.json"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -861,13 +623,9 @@ func TestConsistentSnapshotFlip(t *testing.T) {
 		}
 	}
 
-	if _, err = verifyTuf(t, td, meta["root.json"]); err != nil {
-		t.Fatal(err)
-	}
-
 	// Verify consistent snapshotting was enabled by
 	// checking that 2.snapshot.json is present.
-	repoFiles, err := ioutil.ReadDir(filepath.Join(td, "repository"))
+	repoFiles, err := ioutil.ReadDir(filepath.Join(stack.repoDir, "repository"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -884,58 +642,33 @@ func TestConsistentSnapshotFlip(t *testing.T) {
 }
 
 func TestSignWithEcdsaHexHSM(t *testing.T) {
+	// Initialize.
 	ctx := context.Background()
-	td := t.TempDir()
-
-	rootCA, rootSigner, err := CreateRootCA()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	testTarget := filepath.Join(td, "foo.txt")
-	targetsConfig := map[string]json.RawMessage{testTarget: nil}
-
-	if err := os.WriteFile(testTarget, []byte("abc"), 0600); err != nil {
-		t.Fatal(err)
-	}
-
-	rootSerial, err := CreateTestHsmSigner(td, rootCA, rootSigner)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	snapshotKey := createTestSigner(t)
-	timestampKey := createTestSigner(t)
+	stack := newRepoTestStack(ctx, t)
+	stack.addTarget(t, "foo.txt", "abc", nil)
+	rootKeyRef := stack.genKey(t, true)
 
 	// Initialize succeeds.
-	if err := app.InitCmd(ctx, td, "", 1, targetsConfig, snapshotKey, timestampKey, app.DeprecatedEcdsaFormat); err != nil {
+	if err := app.InitCmd(ctx, stack.repoDir, "", 1,
+		stack.targetsConfig, stack.snapshotRef, stack.timestampRef,
+		true); err != nil {
 		t.Fatal(err)
 	}
 
 	// Sign root
-	rootKey, err := GetTestHsmSigner(ctx, td, *rootSerial)
-	if err != nil {
+	rootSigner := stack.getSigner(t, rootKeyRef)
+	if err := app.SignCmd(ctx, stack.repoDir, []string{"root"},
+		rootSigner, true); err != nil {
 		t.Fatal(err)
 	}
-	rootTufKey, err := keys.ConstructTufKey(ctx, rootKey, app.DeprecatedEcdsaFormat)
+
+	rootTufKey, err := keys.ConstructTufKey(ctx, rootSigner, true)
 	if err != nil {
-		t.Fatal(err)
-	}
-	if err := app.SignCmd(ctx, td, []string{"root"}, rootKey, app.DeprecatedEcdsaFormat); err != nil {
 		t.Fatal(err)
 	}
 
 	// Verify that root has one signature using hex-encoded key.
-	store := tuf.FileSystemStore(td, nil)
-	meta, err := store.GetMeta()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	md, ok := meta["root.json"]
-	if !ok {
-		t.Fatalf("missing root")
-	}
+	md := stack.getManifest(t, "root.json")
 	signed := &data.Signed{}
 	if err := json.Unmarshal(md, signed); err != nil {
 		t.Fatal(err)
@@ -971,84 +704,56 @@ func TestSignWithEcdsaHexHSM(t *testing.T) {
 
 func TestEcdsaHexToPEMMigration(t *testing.T) {
 	ctx := context.Background()
-	td := t.TempDir()
-
-	rootCA, rootSigner, err := CreateRootCA()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	testTarget := filepath.Join(td, "foo.txt")
-	targetsConfig := map[string]json.RawMessage{testTarget: nil}
-
-	if err := os.WriteFile(testTarget, []byte("abc"), 0600); err != nil {
-		t.Fatal(err)
-	}
-
-	rootSerial, err := CreateTestHsmSigner(td, rootCA, rootSigner)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	snapshotKey := createTestSigner(t)
-	timestampKey := createTestSigner(t)
+	stack := newRepoTestStack(ctx, t)
+	stack.addTarget(t, "foo.txt", "abc", nil)
+	rootKeyRef := stack.genKey(t, true)
 
 	// Initialize succeeds with deprecated format.
 	deprecatedEcdsaFormat := true
-	if err := app.InitCmd(ctx, td, "", 1, targetsConfig, snapshotKey, timestampKey, deprecatedEcdsaFormat); err != nil {
+	if err := app.InitCmd(ctx, stack.repoDir, "", 1,
+		stack.targetsConfig, stack.snapshotRef, stack.timestampRef,
+		deprecatedEcdsaFormat); err != nil {
 		t.Fatal(err)
 	}
 
 	// Just to make sure, try this with the PEM signer and expect failure
-	rootKeyPEM, err := GetTestHsmSigner(ctx, td, *rootSerial)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := app.SignCmd(ctx, td, []string{"root"}, rootKeyPEM, false); err == nil {
+	rootSigner := stack.getSigner(t, rootKeyRef)
+	if err := app.SignCmd(ctx, stack.repoDir, []string{"root"}, rootSigner, false); err == nil {
 		t.Fatal("expected error signing with PEM key")
 	}
 
 	// Sign root with deprecated format signer.
-	rootKey, err := GetTestHsmSigner(ctx, td, *rootSerial)
-	if err != nil {
+	if err := app.SignCmd(ctx, stack.repoDir, []string{"root", "targets"},
+		rootSigner, deprecatedEcdsaFormat); err != nil {
 		t.Fatal(err)
-	}
-	rootTufKeyHex, err := keys.ConstructTufKey(ctx, rootKey, deprecatedEcdsaFormat)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := app.SignCmd(ctx, td, []string{"root", "targets"}, rootKey, deprecatedEcdsaFormat); err != nil {
-		t.Fatalf("error signing with deprecated signer %s", err)
 	}
 
 	// Finish publishing & verify
-	snapshotTimestampPublish(ctx, t, td, snapshotKey, timestampKey, deprecatedEcdsaFormat)
-	store := tuf.FileSystemStore(td, nil)
-	meta, err := store.GetMeta()
-	if err != nil {
-		t.Fatal(err)
-	}
-	initialSignedRoot := meta["root.json"]
-	verifyTuf(t, td, initialSignedRoot)
-	checkMetadataVersion(t, td,
+	stack.snapshot(t, deprecatedEcdsaFormat)
+	stack.timestamp(t, deprecatedEcdsaFormat)
+	stack.publish(t)
+
+	// Finish publishing & verify
+	initialSignedRoot := stack.getManifest(t, "root.json")
+	verifyTuf(t, stack.repoDir, initialSignedRoot)
+	checkMetadataVersion(t, stack.repoDir,
 		[]string{"root.json", "targets.json", "snapshot.json", "timestamp.json"},
 		1)
 
 	// Flip the format and re-init! This should add "new" TUF key, same material.
 	deprecatedEcdsaFormat = false
-	if err := app.InitCmd(ctx, td, td, 1, targetsConfig, snapshotKey, timestampKey, deprecatedEcdsaFormat); err != nil {
-		t.Fatal(err)
-	}
-	rootTufKeyPem, err := keys.ConstructTufKey(ctx, rootKey, deprecatedEcdsaFormat)
-	if err != nil {
+	if err := app.InitCmd(ctx, stack.repoDir, stack.repoDir, 1,
+		stack.targetsConfig, stack.snapshotRef, stack.timestampRef,
+		deprecatedEcdsaFormat); err != nil {
 		t.Fatal(err)
 	}
 
 	// Check that only the PEM key IDs are on root & targets role.
-	meta, err = store.GetMeta()
+	rootTufKeyPem, err := keys.ConstructTufKey(ctx, rootSigner, false)
 	if err != nil {
 		t.Fatal(err)
 	}
+	store := tuf.FileSystemStore(stack.repoDir, nil)
 	root, err := prepo.GetRootFromStore(store)
 	if err != nil {
 		t.Fatal(err)
@@ -1068,10 +773,11 @@ func TestEcdsaHexToPEMMigration(t *testing.T) {
 
 	// Check that there are 2 signature pre-entries on root
 	// one for Hex and one for PEM.
-	md, ok := meta["root.json"]
-	if !ok {
-		t.Fatalf("missing root")
+	rootTufKeyHex, err := keys.ConstructTufKey(ctx, rootSigner, true)
+	if err != nil {
+		t.Fatal(err)
 	}
+	md := stack.getManifest(t, "root.json")
 	signed := &data.Signed{}
 	if err := json.Unmarshal(md, signed); err != nil {
 		t.Fatal(err)
@@ -1091,10 +797,7 @@ func TestEcdsaHexToPEMMigration(t *testing.T) {
 	}
 
 	// Check that there is 1 signature pre-entry on targets, just the new PEM.
-	md, ok = meta["targets.json"]
-	if !ok {
-		t.Fatalf("missing targets")
-	}
+	md = stack.getManifest(t, "targets.json")
 	signed = &data.Signed{}
 	if err := json.Unmarshal(md, signed); err != nil {
 		t.Fatal(err)
@@ -1107,26 +810,16 @@ func TestEcdsaHexToPEMMigration(t *testing.T) {
 	}
 
 	// Check that snapshot and timestamp only have 1 key, the new PEM format.
-	meta, err = store.GetMeta()
-	if err != nil {
-		t.Fatal(err)
-	}
 	root, err = prepo.GetRootFromStore(store)
 	if err != nil {
 		t.Fatal(err)
 	}
-	snapshotSigner, err := csignature.SignerVerifierFromKeyRef(ctx, snapshotKey, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	snapshotSigner := stack.getSigner(t, stack.snapshotRef)
 	snapshotKeyPEM, err := keys.ConstructTufKey(ctx, snapshotSigner, deprecatedEcdsaFormat)
 	if err != nil {
 		t.Fatal(err)
 	}
-	timestampSigner, err := csignature.SignerVerifierFromKeyRef(ctx, timestampKey, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	timestampSigner := stack.getSigner(t, stack.timestampRef)
 	timestampKeyPEM, err := keys.ConstructTufKey(ctx, timestampSigner, deprecatedEcdsaFormat)
 	if err != nil {
 		t.Fatal(err)
@@ -1146,70 +839,53 @@ func TestEcdsaHexToPEMMigration(t *testing.T) {
 	}
 
 	// Now sign with both key types.
-	if err := app.SignCmd(ctx, td, []string{"root", "targets"}, rootKeyPEM, true); err != nil {
+	if err := app.SignCmd(ctx, stack.repoDir, []string{"root", "targets"}, rootSigner, true); err != nil {
 		t.Fatal(err)
 	}
 
 	// Finish publishing.
-	snapshotTimestampPublish(ctx, t, td, snapshotKey, timestampKey, deprecatedEcdsaFormat)
+	stack.snapshot(t, deprecatedEcdsaFormat)
+	stack.timestamp(t, deprecatedEcdsaFormat)
+	stack.publish(t)
 
 	// Check version 2.
-	checkMetadataVersion(t, td,
+	checkMetadataVersion(t, stack.repoDir,
 		[]string{"root.json", "targets.json", "snapshot.json", "timestamp.json"},
 		2)
 	// Verify using the bytes of 1.root.json.
-	verifyTuf(t, td, initialSignedRoot)
+	verifyTuf(t, stack.repoDir, initialSignedRoot)
 	// Verify using the bytes of 2.root.json.
-	meta, err = store.GetMeta()
-	if err != nil {
-		t.Fatal(err)
-	}
-	verifyTuf(t, td, meta["root.json"])
+	verifyTuf(t, stack.repoDir, stack.getManifest(t, "2.root.json"))
 }
 
 // Tests snapshot key rotation.
 func TestSnapshotKeyRotate(t *testing.T) {
 	ctx := context.Background()
-	td := t.TempDir()
-
-	rootCA, rootSigner, err := CreateRootCA()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	testTarget := filepath.Join(td, "foo.txt")
-	targetsConfig := map[string]json.RawMessage{testTarget: nil}
-
-	if err := os.WriteFile(testTarget, []byte("abc"), 0600); err != nil {
-		t.Fatal(err)
-	}
-
-	rootSerial, err := CreateTestHsmSigner(td, rootCA, rootSigner)
-	if err != nil {
-		t.Fatal(err)
-	}
-	snapshotKey1 := createTestSigner(t)
-	timestampKey := createTestSigner(t)
+	stack := newRepoTestStack(ctx, t)
+	stack.addTarget(t, "foo.txt", "abc", nil)
+	rootKeyRef := stack.genKey(t, true)
 
 	// Initialize succeeds.
-	if err := app.InitCmd(ctx, td, "", 1, targetsConfig, snapshotKey1, timestampKey, app.DeprecatedEcdsaFormat); err != nil {
+	if err := app.InitCmd(ctx, stack.repoDir, "", 1,
+		stack.targetsConfig, stack.snapshotRef, stack.timestampRef,
+		app.DeprecatedEcdsaFormat); err != nil {
 		t.Fatal(err)
 	}
 
 	// Sign root & targets with key 1
-	rootKey, err := GetTestHsmSigner(ctx, td, *rootSerial)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := app.SignCmd(ctx, td, []string{"root", "targets"}, rootKey, app.DeprecatedEcdsaFormat); err != nil {
+	rootSigner := stack.getSigner(t, rootKeyRef)
+	if err := app.SignCmd(ctx, stack.repoDir, []string{"root", "targets"},
+		rootSigner, app.DeprecatedEcdsaFormat); err != nil {
 		t.Fatal(err)
 	}
 
 	// Sign snapshot and timestamp
-	snapshotTimestampPublish(ctx, t, td, snapshotKey1, timestampKey, app.DeprecatedEcdsaFormat)
+	stack.snapshot(t, app.DeprecatedEcdsaFormat)
+	stack.timestamp(t, app.DeprecatedEcdsaFormat)
+	stack.publish(t)
 
 	// Verify that the snapshot role contains the initial snapshot key id
-	store := tuf.FileSystemStore(td, nil)
+	store := tuf.FileSystemStore(stack.repoDir, nil)
 	root, err := prepo.GetRootFromStore(store)
 	if err != nil {
 		t.Fatal(err)
@@ -1218,10 +894,7 @@ func TestSnapshotKeyRotate(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected snapshot role")
 	}
-	snapshotSigner1, err := csignature.SignerVerifierFromKeyRef(ctx, snapshotKey1, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	snapshotSigner1 := stack.getSigner(t, stack.snapshotRef)
 	snapshotTufKey1, err := keys.ConstructTufKey(ctx, snapshotSigner1, app.DeprecatedEcdsaFormat)
 	if err != nil {
 		t.Fatal(err)
@@ -1235,19 +908,24 @@ func TestSnapshotKeyRotate(t *testing.T) {
 	}
 
 	// Now rotate the snapshot signer out.
-	snapshotKey2 := createTestSigner(t)
+	stack.snapshotRef = createTestSigner(t)
 	// Initialize succeeds.
-	if err := app.InitCmd(ctx, td, td, 1, targetsConfig, snapshotKey2, timestampKey, app.DeprecatedEcdsaFormat); err != nil {
+	if err := app.InitCmd(ctx, stack.repoDir, stack.repoDir, 1,
+		stack.targetsConfig, stack.snapshotRef, stack.timestampRef,
+		app.DeprecatedEcdsaFormat); err != nil {
 		t.Fatal(err)
 	}
 
 	// Sign root & targets with key 1
-	if err := app.SignCmd(ctx, td, []string{"root", "targets"}, rootKey, app.DeprecatedEcdsaFormat); err != nil {
+	if err := app.SignCmd(ctx, stack.repoDir, []string{"root", "targets"},
+		rootSigner, app.DeprecatedEcdsaFormat); err != nil {
 		t.Fatal(err)
 	}
 
 	// Sign snapshot and timestamp
-	snapshotTimestampPublish(ctx, t, td, snapshotKey2, timestampKey, app.DeprecatedEcdsaFormat)
+	stack.snapshot(t, app.DeprecatedEcdsaFormat)
+	stack.timestamp(t, app.DeprecatedEcdsaFormat)
+	stack.publish(t)
 
 	// Expect only the new snapshot key.
 	root, err = prepo.GetRootFromStore(store)
@@ -1258,10 +936,7 @@ func TestSnapshotKeyRotate(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected snapshot role")
 	}
-	snapshotSigner2, err := csignature.SignerVerifierFromKeyRef(ctx, snapshotKey2, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	snapshotSigner2 := stack.getSigner(t, stack.snapshotRef)
 	snapshotTufKey2, err := keys.ConstructTufKey(ctx, snapshotSigner2, app.DeprecatedEcdsaFormat)
 	if err != nil {
 		t.Fatal(err)

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -19,6 +19,7 @@
 package test
 
 import (
+	"bytes"
 	"context"
 	"crypto"
 	"crypto/ecdsa"
@@ -27,19 +28,157 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/asn1"
+	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"math/big"
+	"os"
 	"path/filepath"
+	"testing"
 	"time"
 
 	"github.com/go-piv/piv-go/piv"
 	"github.com/sigstore/cosign/cmd/cosign/cli/pivcli"
+	"github.com/sigstore/cosign/pkg/cosign"
+	csignature "github.com/sigstore/cosign/pkg/signature"
 	"github.com/sigstore/root-signing/cmd/tuf/app"
 	"github.com/sigstore/root-signing/pkg/keys"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	"github.com/sigstore/sigstore/pkg/signature"
+	"github.com/theupdateframework/go-tuf"
 )
+
+type repoTestStack struct {
+	ctx           context.Context
+	repoDir       string
+	hsmRootCA     *x509.Certificate
+	hsmRootSigner crypto.PrivateKey
+	targetsConfig map[string]json.RawMessage
+	snapshotRef   string
+	timestampRef  string
+}
+
+// newRepoTestStack initializes a test stack for e2e
+// testing, setting up a root CA for the HSM keys
+func newRepoTestStack(ctx context.Context, t *testing.T) *repoTestStack {
+	td := t.TempDir()
+
+	rootCA, rootSigner, err := CreateRootCA()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return &repoTestStack{
+		repoDir:       td,
+		hsmRootCA:     rootCA,
+		hsmRootSigner: rootSigner,
+		targetsConfig: make(map[string]json.RawMessage, 0),
+		snapshotRef:   createTestSigner(t),
+		timestampRef:  createTestSigner(t),
+	}
+}
+
+func (s *repoTestStack) addTarget(t *testing.T, name, content string, custom json.RawMessage) {
+	testTarget := filepath.Join(s.repoDir, name)
+	if err := os.WriteFile(testTarget, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	s.targetsConfig[testTarget] = custom
+}
+
+func (s *repoTestStack) removeTarget(t *testing.T, name string) {
+	delete(s.targetsConfig, filepath.Join(s.repoDir, name))
+}
+
+func (s *repoTestStack) genKey(t *testing.T, hsm bool) string {
+	if hsm {
+		keyRef, err := CreateTestHsmSigner(s.repoDir, s.hsmRootCA, s.hsmRootSigner)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return keyRef
+	}
+	return createTestSigner(t)
+}
+
+func (s *repoTestStack) getSigner(t *testing.T, ref string) signature.Signer {
+	signer, err := signature.LoadSignerFromPEMFile(ref, crypto.SHA256, nil)
+	if err != nil {
+		signer, err := csignature.SignerVerifierFromKeyRef(s.ctx, ref, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return signer
+	}
+	return signer
+}
+
+func (s *repoTestStack) removeHsmKey(t *testing.T, ref string) {
+	if err := os.RemoveAll(filepath.Dir(ref)); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func (s *repoTestStack) getManifest(t *testing.T, manifest string) json.RawMessage {
+	store := tuf.FileSystemStore(s.repoDir, nil)
+	meta, err := store.GetMeta()
+	if err != nil {
+		t.Fatal(err)
+	}
+	md, ok := meta[manifest]
+	if !ok {
+		t.Fatalf("missing %s", manifest)
+	}
+	return md
+}
+
+func (s *repoTestStack) snapshot(t *testing.T, deprecated bool) {
+	if err := app.SnapshotCmd(s.ctx, s.repoDir); err != nil {
+		t.Fatalf("expected Snapshot command to pass, got err: %s", err)
+	}
+	snapshotSigner, err := csignature.SignerVerifierFromKeyRef(s.ctx, s.snapshotRef, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := app.SignCmd(s.ctx, s.repoDir, []string{"snapshot"}, snapshotSigner, deprecated); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func (s *repoTestStack) timestamp(t *testing.T, deprecated bool) {
+	if err := app.TimestampCmd(s.ctx, s.repoDir); err != nil {
+		t.Fatalf("expected timestamp command to pass, got err: %s", err)
+	}
+	timestampSigner, err := csignature.SignerVerifierFromKeyRef(s.ctx, s.timestampRef, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := app.SignCmd(s.ctx, s.repoDir, []string{"timestamp"}, timestampSigner, deprecated); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func (s *repoTestStack) publish(t *testing.T) {
+	if err := app.PublishCmd(s.ctx, s.repoDir); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Create fake key signer in testDirectory. Returns file reference to signer.
+func createTestSigner(t *testing.T) string {
+	keys, err := cosign.GenerateKeyPair(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	temp := t.TempDir()
+	f, _ := os.CreateTemp(temp, "*.key")
+
+	if _, err := io.Copy(f, bytes.NewBuffer(keys.PrivateBytes)); err != nil {
+		t.Fatal(err)
+	}
+	return f.Name()
+}
 
 func CreateRootCA() (*x509.Certificate, crypto.PrivateKey, error) {
 	// set up our CA certificate
@@ -126,18 +265,10 @@ func createTestAttestations(root *x509.Certificate, rootSigner crypto.PrivateKey
 	return deviceCert, keyCert, nil
 }
 
-func GetTestHsmSigner(ctx context.Context, testDir string, serial uint32) (signature.Signer, error) {
-	// read private key from file.
-	serialStr := fmt.Sprint(serial)
-	privKeyFile := filepath.Join(testDir, "keys", serialStr, serialStr+"_privkey.pem")
-
-	return signature.LoadSignerVerifierFromPEMFile(privKeyFile, crypto.SHA256, nil)
-}
-
-func CreateTestHsmSigner(testDir string, root *x509.Certificate, rootSigner crypto.PrivateKey) (*uint32, error) {
+func CreateTestHsmSigner(testDir string, root *x509.Certificate, rootSigner crypto.PrivateKey) (string, error) {
 	generated, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 	pub := &generated.PublicKey
 	n, _ := rand.Int(rand.Reader, big.NewInt(100000000))
@@ -145,16 +276,16 @@ func CreateTestHsmSigner(testDir string, root *x509.Certificate, rootSigner cryp
 
 	deviceCert, keyCert, err := createTestAttestations(root, rootSigner, pub, int(serial))
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
 	deviceCertPem, err := cryptoutils.MarshalCertificateToPEM(deviceCert)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 	keyCertPem, err := cryptoutils.MarshalCertificateToPEM(keyCert)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
 	keyAndAttestations := &app.KeyAndAttestations{
@@ -172,18 +303,18 @@ func CreateTestHsmSigner(testDir string, root *x509.Certificate, rootSigner cryp
 
 	// Write to repository/keys/SERIAL_NUM/SERIAL_NUM_pubkey.pem, etc
 	if err := app.WriteKeyData(keyAndAttestations, testDir); err != nil {
-		return nil, err
+		return "", err
 	}
 
 	b, err := cryptoutils.MarshalPrivateKeyToPEM(generated)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
 	serialStr := fmt.Sprint(keyAndAttestations.Attestations.KeyAttestation.Serial)
 	privKeyFile := filepath.Join(testDir, "keys", serialStr, serialStr+"_privkey.pem")
 	if err := ioutil.WriteFile(privKeyFile, []byte(b), 0644); err != nil {
-		return nil, err
+		return "", err
 	}
-	return &serial, nil
+	return privKeyFile, nil
 }


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Fixes https://github.com/sigstore/root-signing/issues/293

* fix: Properly handles updates for snapshot and timestamp keys

Previously, we would `AddVerificationKey` for any specified snapshot/timestamp key but we would NOT revoke any old ones. This revokes any old ones. This is important for v5 so when we re-interpret keys as PEM, we properly revoke the old hex keys.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->