### PR TITLE
feat: add verify log commands for matching pubkeys

### DIFF
--- a/cmd/tuf/app/init.go
+++ b/cmd/tuf/app/init.go
@@ -340,7 +340,7 @@ func getKeysFromDir(dir string, deprecatedKeyFormat bool) ([]*data.PublicKey, er
 			if err != nil {
 				return nil, err
 			}
-			tufKey, err := pkeys.ToTufKey(*key, deprecatedKeyFormat)
+			tufKey, err := pkeys.EcdsaTufKey(key.PublicKey, deprecatedKeyFormat)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/keys/keys.go
+++ b/pkg/keys/keys.go
@@ -114,10 +114,6 @@ func EcdsaTufKey(pub *ecdsa.PublicKey, deprecated bool) (*data.PublicKey, error)
 	}, nil
 }
 
-func ToTufKey(key SigningKey, deprecated bool) (*data.PublicKey, error) {
-	return EcdsaTufKey(key.PublicKey, deprecated)
-}
-
 func getSerialNumber(c *x509.Certificate) (*int, error) {
 	// Retrieves the serial number from the OID extension in the certificate
 	for _, e := range c.Extensions {

--- a/pkg/keys/keys_test.go
+++ b/pkg/keys/keys_test.go
@@ -160,11 +160,11 @@ func TestToSigningKey(t *testing.T) {
 				t.Errorf("unexpected error generating signing key (%s): %s", tt.name, err)
 			}
 			if tt.expectSuccess {
-				hexPubKey, err := ToTufKey(*key, true)
+				hexPubKey, err := EcdsaTufKey(key.PublicKey, true)
 				if err != nil {
 					t.Errorf("unexpected error generating hex TUF public key: %s", err)
 				}
-				pemPubKey, err := ToTufKey(*key, false)
+				pemPubKey, err := EcdsaTufKey(key.PublicKey, false)
 				if err != nil {
 					t.Errorf("unexpected error generating PEM TUF public key: %s", err)
 				}


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

Sample output:
```
Outputting key verification and OpenSSL commands...

VERIFIED KEY WITH SERIAL NUMBER 13078778
TUF key ids: 
	2f64fb5eac0cf94dd39bb45308b98920055e9a0d8e012a7220787834c60aef97 [deprecated]
	ff51e17fcf253119b7033f6f57512631da4a0969442afcf9fc8b141c7f2be99c [new]

VERIFIED KEY WITH SERIAL NUMBER 14470876
TUF key ids: 
	eaf22372f417dd618a46f6c627dbc276e9fd30a004fc94f9be946e73f8bd090b [deprecated]
	25a0eb450fd3ee2bd79218c963dce3f1cc6118badf251bf149f0bd07d5cabe99 [new]

VERIFIED KEY WITH SERIAL NUMBER 15938765
TUF key ids: 
	f40f32044071a9365505da3d1e3be6561f6f22d0e60cf51df783999f6c3429cb [deprecated]
	f5312f542c21273d9485a49394386c4575804770667f2ddb59b3bf0669fddd2f [new]

VERIFIED KEY WITH SERIAL NUMBER 15938791
TUF key ids: 
	f505595165a177a41750a8e864ed1719b1edfccd5a426fd2c0ffda33ce7ff209 [deprecated]
	7f7513b25429a64473e10ce3ad2f3da372bbdd14b65d07bbaf547e7c8bbbe62b [new]

VERIFIED KEY WITH SERIAL NUMBER 18158855
TUF key ids: 
	75e867ab10e121fdef32094af634707f43ddd79c6bab8ad6c5ab9f03f4ea8c90 [deprecated]
	2e61cd0cbf4a8f45809bda9f7f78c0d33ad11842ff94ae340873e2664dc843de [new]

 To match pubkey values of the two TUF key IDs, perform the following command and verify a match:

	export NEW_ID=${NEW_ID}
	export DEPRECATED_ID=${DEPRECATED_ID}
	cat ceremony/2022-09-21/staged/root.json | jq --arg id "${NEW_ID}" -r '.signed.keys[$id].keyval.public' | openssl ec -pubin -inform PEM -text -noout
	cat ceremony/2022-09-21/repository/root.json | jq --arg id "${DEPRECATED_ID}" -r '.signed.keys[$id].keyval.public'

# To manually verify the chain for any key ID

	export SERIAL_NUMBER=${SERIAL_NUMBER}
	openssl verify -verbose -x509_strict -CAfile <(cat piv-attestation-ca.pem ceremony/2022-09-21/keys/${SERIAL_NUMBER}/${SERIAL_NUMBER}_device_cert.pem) ceremony/2022-09-21/keys/${SERIAL_NUMBER}/${SERIAL_NUMBER}_key_cert.pem

# Manually extract the public key for any key ID and match with published

	export SERIAL_NUMBER=${SERIAL_NUMBER}
	openssl x509 -in ceremony/2022-09-21/keys/${SERIAL_NUMBER}/${SERIAL_NUMBER}_key_cert.pem -pubkey -noout
	cat ceremony/2022-09-21/keys/${SERIAL_NUMBER}/${SERIAL_NUMBER}_pubkey.pem
```

Adds commands for matching pubkeys between old and new key IDs