### PR TITLE
fix: fix verification of a staged root to include previous root validation

### DIFF
--- a/cmd/verify/app/repository.go
+++ b/cmd/verify/app/repository.go
@@ -152,7 +152,7 @@ func verifyStagedMetadata(repository string) error {
 		if !errors.Is(err, repo.ErrNoPreviousRoot) {
 			return fmt.Errorf("error getting previous root: %w", err)
 		}
-	} else if err == nil {
+	} else {
 		prevRootExists = true
 		prevRootBytes, ok := meta[fmt.Sprintf("%d.root.json", int(prevRoot.Version))]
 		if !ok {

--- a/cmd/verify/app/repository.go
+++ b/cmd/verify/app/repository.go
@@ -132,14 +132,40 @@ func verifyStagedMetadata(repository string) error {
 	// and verifies the signatures in each file.
 	store := tuf.FileSystemStore(repository, nil)
 
+	meta, err := store.GetMeta()
+	if err != nil {
+		return err
+	}
+
 	db, thresholds, err := repo.CreateDb(store)
 	if err != nil {
 		return err
 	}
 
-	meta, err := store.GetMeta()
+	// Create a DB with just the previous root for root verification against
+	// the previous keys
+	prevRootExists := false
+	var prevDb *verify.DB
+	var prevThresholds map[string]int
+	prevRoot, err := repo.GetPreviousRootFromStore(store)
 	if err != nil {
-		return err
+		if !errors.Is(err, repo.ErrNoPreviousRoot) {
+			return fmt.Errorf("error getting previous root: %w", err)
+		}
+	} else if err == nil {
+		prevRootExists = true
+		prevRootBytes, ok := meta[fmt.Sprintf("%d.root.json", int(prevRoot.Version))]
+		if !ok {
+			// This is an error, we should have a previous root.
+			return fmt.Errorf("expected %d.root.json in store", prevRoot.Version)
+		}
+		var err error
+		prevDb, prevThresholds, err = repo.CreateDb(
+			tuf.MemoryStore(map[string]json.RawMessage{
+				"root.json": prevRootBytes}, nil))
+		if err != nil {
+			return err
+		}
 	}
 
 	for name, md := range meta {
@@ -168,35 +194,51 @@ func verifyStagedMetadata(repository string) error {
 		}
 		signed.Signatures = sigs
 
-		if err = db.VerifySignatures(signed, name); err != nil {
-			if _, ok := err.(verify.ErrRoleThreshold); ok {
-				// we may not have all the sig, allow partial sigs for success
-				log.Printf("\tContains %d/%d valid signatures\n", err.(verify.ErrRoleThreshold).Actual, thresholds[name])
-				_, err := PrintAndGetSignedMeta(name, signed.Signed)
-				if err != nil {
-					return err
-				}
-			} else if err.Error() == verify.ErrNoSignatures.Error() {
-				// We do not return an error here so we can log unsigned metadata
-				log.Printf("\tContains 0/%d valid signatures\n", thresholds[name])
-				_, err := PrintAndGetSignedMeta(name, signed.Signed)
-				if err != nil {
-					return err
-				}
-			} else {
+		validSigs, err := verifySignatures(db, signed, name)
+		if err != nil {
+			log.Printf("\tError verifying: %s\n", err)
+			return err
+		}
+		if validSigs == thresholds[name] {
+			log.Printf("\tSuccess! Signatures valid and threshold achieved\n")
+		} else {
+			log.Printf("\tContains %d/%d valid signatures from the current staged metadata\n", validSigs, thresholds[name])
+		}
+
+		if prevRootExists && name == "root" {
+			// Also verify from the previous root for the root role.
+			validSigs, err := verifySignatures(prevDb, signed, name)
+			if err != nil {
 				log.Printf("\tError verifying: %s\n", err)
 				return err
 			}
-		} else {
-			log.Printf("\tSuccess! Signatures valid and threshold achieved\n")
-			_, err := PrintAndGetSignedMeta(name, signed.Signed)
-			if err != nil {
-				return err
+			if validSigs == prevThresholds[name] {
+				log.Printf("\tSuccess! Signatures valid and threshold achieved from the previous root\n")
+			} else {
+				log.Printf("\tContains %d/%d valid signatures from the previous root\n", validSigs, prevThresholds[name])
 			}
+		}
+
+		if _, err := PrintAndGetSignedMeta(name, signed.Signed); err != nil {
+			return err
 		}
 	}
 
 	return nil
+}
+
+func verifySignatures(db *verify.DB, s *data.Signed, role string) (int, error) {
+	err := db.VerifySignatures(s, role)
+	if _, ok := err.(verify.ErrRoleThreshold); ok {
+		return err.(verify.ErrRoleThreshold).Actual, nil
+	} else if errors.Is(err, verify.ErrNoSignatures) {
+		return 0, nil
+	} else if err != nil {
+		return 0, err
+	}
+	// We have success, a threshold number of signers signed.
+	dbRole := db.GetRole(role)
+	return dbRole.Threshold, nil
 }
 
 func getClientState(local client.LocalStore) (map[string]signedMeta, error) {
@@ -259,7 +301,7 @@ var repositoryCmd = &cobra.Command{
 			validUntil = &parsedTime
 		}
 
-		if err := VerifyCmd(staged, root.String(), repository, validUntil, roles); err != nil {
+		if err := VerifyCmd(staged, repository, root.String(), validUntil, roles); err != nil {
 			log.Println(err.Error())
 		}
 	},

--- a/pkg/repo/repo_test.go
+++ b/pkg/repo/repo_test.go
@@ -171,3 +171,44 @@ func TestUpdateRoleKeys(t *testing.T) {
 		t.Errorf("expected root keys with IDs %s %s", newPk.IDs()[0], pk.IDs()[0])
 	}
 }
+
+func TestGetPreviousRootFromStore(t *testing.T) {
+	tests := []struct {
+		name            string
+		dir             string
+		expectedVersion int
+		shouldErr       bool
+	}{
+		{
+			name:      "root role - initial root",
+			dir:       "./testdata/single_root",
+			shouldErr: true,
+		},
+		{
+			name:            "rotated root keys role",
+			dir:             "./testdata/multiple_root",
+			expectedVersion: 3,
+			shouldErr:       false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wd, err := os.Getwd()
+			if err != nil {
+				t.Fatal(err)
+			}
+			dirPath := filepath.Join(wd, tt.dir)
+			store := tuf.FileSystemStore(dirPath, nil)
+			prevRoot, err := GetPreviousRootFromStore(store)
+			if (err != nil) != tt.shouldErr {
+				t.Errorf("expected error %t got %s", tt.shouldErr, err)
+			}
+			if err != nil {
+				return
+			}
+			if prevRoot.Version != int64(tt.expectedVersion) {
+				t.Errorf("expected prev root version %d, got %d", tt.expectedVersion, prevRoot.Version)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

**DOES NOT AFFECT SIGNING SCRIPTS OF CLIENT VERIFICATION, JUST VERIFICATION OF STAGING METADATA AND SIGNING**

* fix: Fixes verification script of a staged root to include verification against the keys of the previous root

Example output (from Santiago's test signing)
```
$ ./verify repository --repository /home/asraa/git/root-signing/ceremony/2022-09-22 --staged
STAGED METADATA

Outputting metadata verification at /home/asraa/git/root-signing/ceremony/2022-09-22...

Verifying rekor.json...
	Contains 0/1 valid signatures from the current staged metadata
	rekor version 4, expires 2023/03/22

Verifying root.json...
	Contains 1/3 valid signatures from the current staged metadata
	Contains 1/3 valid signatures from the previous root
	root version 5, expires 2023/03/22

Verifying targets.json...
	Contains 1/3 valid signatures from the current staged metadata
	targets version 5, expires 2023/03/22

Verifying revocation.json...
	Contains 0/1 valid signatures from the current staged metadata
	revocation version 2, expires 2023/03/22
```

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->