### PR TITLE
fix: fix snapshot and timestamp job to handle deprecated key IDs

### DIFF
--- a/.github/workflows/snapshot-timestamp.yml
+++ b/.github/workflows/snapshot-timestamp.yml
@@ -72,9 +72,9 @@ jobs:
       - name: snapshot and timestamp
         run: |
           ./tuf snapshot -repository $REPO
-          ./tuf sign -repository $REPO -roles snapshot -key ${SNAPSHOT_KEY}
+          ./tuf sign -repository $REPO -roles snapshot -key ${SNAPSHOT_KEY} -add-deprecated true
           ./tuf timestamp -repository $REPO
-          ./tuf sign -repository $REPO -roles timestamp -key ${TIMESTAMP_KEY}
+          ./tuf sign -repository $REPO -roles timestamp -key ${TIMESTAMP_KEY} -add-deprecated true
       - name: publish
         run: |
           ./tuf publish -repository $REPO
@@ -92,7 +92,7 @@ jobs:
       issues: 'write'
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    if: needs.snapshot_and_timestamp.result == 'failure'
+    if: always() && needs.snapshot_and_timestamp.result == 'failure'
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
       - run: |
@@ -131,7 +131,7 @@ jobs:
       issues: 'write'
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    if: needs.push.result == 'failure'
+    if: always() && needs.push.result == 'failure'
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
       - run: |


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

The recent snapshot/timestamp job failed because of a key ID mismatch
https://github.com/sigstore/root-signing/actions/runs/3101959937/jobs/5023806276
because we are still using deprecated flags and didn't explicitly add the `-add-deprecated` flag to the sign CMDs.

Also, the if-failed jobs never triggered because they were skipped with an `always()` condition.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->