### PR TITLE
fix: fix targets expiration regression

### DIFF
--- a/cmd/tuf/app/add-delegation.go
+++ b/cmd/tuf/app/add-delegation.go
@@ -129,7 +129,7 @@ func DelegationCmd(ctx context.Context, directory, name, path string, terminatin
 		Paths:       []string{path},
 		Threshold:   1,
 		Terminating: terminating,
-	}, keys, getExpiration("targets")); err != nil {
+	}, keys, GetExpiration("targets")); err != nil {
 		// If delegation already added, then we just want to bump version and expiration.
 		fmt.Fprintln(os.Stdout, "Adding targets delegation: ", err)
 	}
@@ -162,7 +162,7 @@ func DelegationCmd(ctx context.Context, directory, name, path string, terminatin
 				return err
 			}
 			fmt.Fprintln(os.Stderr, "Created target file at ", to.Name())
-			if err := repo.AddTargetsWithExpiresToPreferredRole([]string{base}, custom, getExpiration("targets"), name); err != nil {
+			if err := repo.AddTargetsWithExpiresToPreferredRole([]string{base}, custom, GetExpiration("targets"), name); err != nil {
 				return fmt.Errorf("error adding targets %w", err)
 			}
 		}

--- a/cmd/tuf/app/init.go
+++ b/cmd/tuf/app/init.go
@@ -55,7 +55,7 @@ var RoleExpiration = map[string][]int{
 	"timestamp": {0, 0, 14},
 }
 
-func getExpiration(role string) time.Time {
+func GetExpiration(role string) time.Time {
 	// Default expiration for any delegated role is the targets expiration.
 	times, ok := RoleExpiration[role]
 	if !ok {
@@ -169,7 +169,7 @@ func InitCmd(ctx context.Context, directory, previous string,
 	// Add any keys in the keys/ subfolder to root and targets.
 	for _, role := range []string{"root", "targets"} {
 		if err := prepo.UpdateRoleKeys(repo, store, role, keys,
-			getExpiration(role)); err != nil {
+			GetExpiration(role)); err != nil {
 			return err
 		}
 		if err := repo.SetThreshold(role, threshold); err != nil {
@@ -192,7 +192,7 @@ func InitCmd(ctx context.Context, directory, previous string,
 
 		// Update keys.
 		if err := prepo.UpdateRoleKeys(repo, store, role, []*data.PublicKey{tufKey},
-			getExpiration(role)); err != nil {
+			GetExpiration(role)); err != nil {
 			return err
 		}
 
@@ -223,7 +223,7 @@ func InitCmd(ctx context.Context, directory, previous string,
 			return err
 		}
 		fmt.Fprintln(os.Stderr, "Created target file at ", to.Name())
-		if err := repo.AddTargetWithExpiresToPreferredRole(tt, custom, getExpiration("targets"), "targets"); err != nil {
+		if err := repo.AddTargetWithExpiresToPreferredRole(tt, custom, GetExpiration("targets"), "targets"); err != nil {
 			return fmt.Errorf("error adding targets %w", err)
 		}
 		expectedTargets[tt] = true
@@ -243,13 +243,13 @@ func InitCmd(ctx context.Context, directory, previous string,
 	// Only call RemoveTargetsWithExpires if there are targets to remove.
 	// Calling the function with an empty slice will remove all targets.
 	if len(targetsToRemove) > 0 {
-		if err := repo.RemoveTargetsWithExpires(targetsToRemove, getExpiration("targets")); err != nil {
+		if err := repo.RemoveTargetsWithExpires(targetsToRemove, GetExpiration("targets")); err != nil {
 			return fmt.Errorf("error removing old targets: %w", err)
 		}
 	}
 
 	// Reset and delegations: they will be updated in DelegationCmd.
-	if err := repo.ResetTargetsDelegations("targets"); err != nil {
+	if err := repo.ResetTargetsDelegationsWithExpires("targets", GetExpiration("targets")); err != nil {
 		return err
 	}
 
@@ -277,7 +277,7 @@ func InitCmd(ctx context.Context, directory, previous string,
 		return err
 	}
 	root.Version = curRootVersion + 1
-	root.Expires = getExpiration("root")
+	root.Expires = GetExpiration("root")
 	root.ConsistentSnapshot = ConsistentSnapshot
 	allRootKeys, err := prepo.GetSigningKeyIDsForRole("root", store)
 	if err != nil {

--- a/cmd/tuf/app/snapshot.go
+++ b/cmd/tuf/app/snapshot.go
@@ -81,6 +81,6 @@ func SnapshotCmd(ctx context.Context, directory string) error {
 		return err
 	}
 
-	snapshotReturnErr = repo.SnapshotWithExpires(getExpiration("snapshot"))
+	snapshotReturnErr = repo.SnapshotWithExpires(GetExpiration("snapshot"))
 	return snapshotReturnErr
 }

--- a/cmd/tuf/app/timestamp.go
+++ b/cmd/tuf/app/timestamp.go
@@ -55,5 +55,5 @@ func TimestampCmd(ctx context.Context, directory string) error {
 	if err != nil {
 		return err
 	}
-	return repo.TimestampWithExpires(getExpiration("timestamp"))
+	return repo.TimestampWithExpires(GetExpiration("timestamp"))
 }

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -29,6 +29,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/secure-systems-lab/go-securesystemslib/cjson"
@@ -1009,6 +1010,16 @@ func TestProdTargetsConfig(t *testing.T) {
 		if !reflect.DeepEqual(v1, v2) {
 			t.Errorf("expected custom %s, got %s", targetsConfig[name], *tFiles.Custom)
 		}
+	}
+
+	// Verify the expiration of targets
+	store := tuf.FileSystemStore(stack.repoDir, nil)
+	targets, err := prepo.GetTargetsFromStore(store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if targets.Expires.Sub(app.GetExpiration("targets")).Round(time.Hour) != 0 {
+		t.Errorf("expected expiration %s", app.GetExpiration("targets"))
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

From https://github.com/sigstore/root-signing/pull/407

Caught by the amazing reviewers!

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->