### PR TITLE
fix: fix targets removal so it doesn't interfere with delegations

### DIFF
--- a/cmd/tuf/app/init.go
+++ b/cmd/tuf/app/init.go
@@ -203,6 +203,7 @@ func InitCmd(ctx context.Context, directory, previous string,
 	}
 
 	// Add targets (copy them into the repository and add them to the targets.json)
+	// Add the new targets in the config.
 	expectedTargets := make(map[string]bool)
 	for tt, custom := range targetsConfig {
 		from, err := os.Open(filepath.Join(targetsDir, tt))
@@ -228,8 +229,6 @@ func InitCmd(ctx context.Context, directory, previous string,
 		}
 		expectedTargets[tt] = true
 	}
-
-	// Remove old targets that were not included in config.
 	targetsToRemove := []string{}
 	allTargets, err := repo.Targets()
 	if err != nil {
@@ -238,13 +237,6 @@ func InitCmd(ctx context.Context, directory, previous string,
 	for path := range allTargets {
 		if !expectedTargets[path] {
 			targetsToRemove = append(targetsToRemove, path)
-		}
-	}
-	// Only call RemoveTargetsWithExpires if there are targets to remove.
-	// Calling the function with an empty slice will remove all targets.
-	if len(targetsToRemove) > 0 {
-		if err := repo.RemoveTargetsWithExpires(targetsToRemove, GetExpiration("targets")); err != nil {
-			return fmt.Errorf("error removing old targets: %w", err)
 		}
 	}
 
@@ -266,6 +258,12 @@ func InitCmd(ctx context.Context, directory, previous string,
 	if err != nil {
 		return err
 	}
+	// Remove any targets not present: only removes from targets to avoid
+	// removing from delegations.
+	for _, tt := range targetsToRemove {
+		delete(t.Targets, tt)
+	}
+
 	if err := setMetaWithSigKeyIDs(store, "targets.json", t, maps.Keys(targetKeys)); err != nil {
 		return err
 	}

--- a/cmd/tuf/app/init.go
+++ b/cmd/tuf/app/init.go
@@ -260,6 +260,9 @@ func InitCmd(ctx context.Context, directory, previous string,
 	}
 	// Remove any targets not present: only removes from targets to avoid
 	// removing from delegations.
+	// See https://github.com/theupdateframework/go-tuf/issues/400 and
+	// https://github.com/theupdateframework/go-tuf/blob/f75cbcc8550dfb9311c6723999fe7b1d3d2bc116/repo.go#L1230
+	// for why we avoid `repo.RemoveTargetsWithExpires`
 	for _, tt := range targetsToRemove {
 		delete(t.Targets, tt)
 	}


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

As a bypass for https://github.com/theupdateframework/go-tuf/issues/400: which describes that `repo.RemoveTargetsWithExpires` removes the targets from ALL roles, including delegations.

Because of this, we removed `rekor.0.pub` from the top-level targets AND the rekor delegation, staging a new version of the delegate where we did not mean to.

This was noted in @joshuagl 's review: https://github.com/sigstore/root-signing/pull/410#pullrequestreview-1123491590

Note: we have an e2e regression test for target rotation covered.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->