### PR TITLE
fix: fix null value on delegations roles

### DIFF
--- a/cmd/tuf/app/init.go
+++ b/cmd/tuf/app/init.go
@@ -248,11 +248,6 @@ func InitCmd(ctx context.Context, directory, previous string,
 		}
 	}
 
-	// Reset and delegations: they will be updated in DelegationCmd.
-	if err := repo.ResetTargetsDelegationsWithExpires("targets", GetExpiration("targets")); err != nil {
-		return err
-	}
-
 	if err := repo.SetThreshold("targets", threshold); err != nil {
 		return err
 	}
@@ -262,6 +257,10 @@ func InitCmd(ctx context.Context, directory, previous string,
 	if err != nil {
 		return err
 	}
+	// We reset and delegations: they will be updated in DelegationCmd.
+	// TODO(https://github.com/theupdateframework/go-tuf/issues/402): replace
+	// with `repo.ResetTargetsDelegationsWithExpires` when this issue is resolved.
+	t.Delegations = nil
 	targetKeys, err := prepo.GetSigningKeyIDsForRole("targets", store)
 	if err != nil {
 		return err

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -1056,10 +1056,7 @@ func TestDelegationsClearedOnInit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(targets.Delegations.Roles) != 0 {
-		t.Errorf("Expected top-level targets delegation roles to be cleared")
-	}
-	if len(targets.Delegations.Keys) != 0 {
-		t.Errorf("Expected top-level targets delegation keys to be cleared")
+	if targets.Delegations != nil {
+		t.Errorf("Expected top-level targets delegations to be cleared")
 	}
 }


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Fixes a comment about `null` values in the JSON from https://github.com/sigstore/root-signing/pull/410

Without this, we are not python compatible (or likely rust too).

Left a TODO to fix when https://github.com/theupdateframework/go-tuf/issues/402 is resolved.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->