### PR TITLE
fix: add functionality to bump a version

### DIFF
--- a/cmd/tuf/app/add-delegation.go
+++ b/cmd/tuf/app/add-delegation.go
@@ -185,9 +185,9 @@ func DelegationCmd(ctx context.Context, directory, name, path string, terminatin
 	if err != nil {
 		return err
 	}
-	signed, err := jsonMarshal(t)
+	signed, err := prepo.MarshalMetadata(t)
 	if err != nil {
 		return err
 	}
-	return setSignedMeta(store, "targets.json", &data.Signed{Signatures: sigs, Signed: signed})
+	return prepo.SetSignedMeta(store, "targets.json", &data.Signed{Signatures: sigs, Signed: signed})
 }

--- a/pkg/repo/repo.go
+++ b/pkg/repo/repo.go
@@ -328,9 +328,10 @@ func SetSignedMeta(store tuf.LocalStore, role string, s *data.Signed) error {
 }
 
 // BumpMetadataVersion increments the version of the manifest.
-// This ONLY handles targets types! The repo.SetRootVersion, repo.SetTargetsVersion,
-// or repo.SetSnapshotVersion, or repo.SetTimestampVersion handle top-level
-// metadata.
+// Note: This does NOT increase expiration!
+// This ONLY handles delegated targets roles! The repo.SetRootVersion,
+// repo.SetTargetsVersion, repo.SetSnapshotVersion, or repo.SetTimestampVersion
+// handle top-level metadata.
 func BumpMetadataVersion(store tuf.LocalStore, name string) error {
 	for _, topName := range []string{"root", "targets", "snapshot", "timestamp"} {
 		if name == topName {

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -189,7 +189,7 @@ func TestSignRootTargets(t *testing.T) {
 	// Sign root and targets.
 	rootSigner := stack.getSigner(t, rootKeyRef)
 	if err := app.SignCmd(ctx, stack.repoDir, []string{"root", "targets"},
-		rootSigner, app.DeprecatedEcdsaFormat); err != nil {
+		rootSigner, false, app.DeprecatedEcdsaFormat); err != nil {
 		t.Fatal(err)
 	}
 
@@ -254,7 +254,7 @@ func TestSnapshotUnvalidatedFails(t *testing.T) {
 	// Now sign root and targets with 1/1 threshold key.
 	rootSigner := stack.getSigner(t, rootKeyRef)
 	if err := app.SignCmd(ctx, stack.repoDir, []string{"root", "targets"},
-		rootSigner, app.DeprecatedEcdsaFormat); err != nil {
+		rootSigner, false, app.DeprecatedEcdsaFormat); err != nil {
 		t.Fatal(err)
 	}
 
@@ -304,7 +304,7 @@ func TestPublishSuccess(t *testing.T) {
 	// Sign root & targets
 	rootSigner := stack.getSigner(t, rootKeyRef)
 	if err := app.SignCmd(ctx, stack.repoDir, []string{"root", "targets"},
-		rootSigner, app.DeprecatedEcdsaFormat); err != nil {
+		rootSigner, false, app.DeprecatedEcdsaFormat); err != nil {
 		t.Fatal(err)
 	}
 
@@ -363,7 +363,7 @@ func TestRotateRootKey(t *testing.T) {
 	// Sign root & targets with key 1
 	rootSigner1 := stack.getSigner(t, rootKeyRef1)
 	if err := app.SignCmd(ctx, stack.repoDir, []string{"root", "targets"},
-		rootSigner1, app.DeprecatedEcdsaFormat); err != nil {
+		rootSigner1, false, app.DeprecatedEcdsaFormat); err != nil {
 		t.Fatal(err)
 	}
 	rootTufKey1, err := keys.ConstructTufKey(ctx, rootSigner1, app.DeprecatedEcdsaFormat)
@@ -438,7 +438,8 @@ func TestRotateRootKey(t *testing.T) {
 	}
 
 	// Sign root & targets
-	if err := app.SignCmd(ctx, stack.repoDir, []string{"root", "targets"}, rootSigner1, app.DeprecatedEcdsaFormat); err != nil {
+	if err := app.SignCmd(ctx, stack.repoDir, []string{"root", "targets"}, rootSigner1,
+		false, app.DeprecatedEcdsaFormat); err != nil {
 		t.Fatal(err)
 	}
 
@@ -470,7 +471,7 @@ func TestRotateTarget(t *testing.T) {
 	// Sign root & targets
 	rootSigner := stack.getSigner(t, rootKeyRef)
 	if err := app.SignCmd(ctx, stack.repoDir, []string{"root", "targets"},
-		rootSigner, app.DeprecatedEcdsaFormat); err != nil {
+		rootSigner, false, app.DeprecatedEcdsaFormat); err != nil {
 		t.Fatal(err)
 	}
 
@@ -511,7 +512,7 @@ func TestRotateTarget(t *testing.T) {
 
 	// Sign root & targets
 	if err := app.SignCmd(ctx, stack.repoDir, []string{"root", "targets"},
-		rootSigner, app.DeprecatedEcdsaFormat); err != nil {
+		rootSigner, false, app.DeprecatedEcdsaFormat); err != nil {
 		t.Fatal(err)
 	}
 
@@ -559,7 +560,7 @@ func TestConsistentSnapshotFlip(t *testing.T) {
 	// Sign root & targets
 	rootSigner := stack.getSigner(t, rootKeyRef)
 	if err := app.SignCmd(ctx, stack.repoDir, []string{"root", "targets"},
-		rootSigner, app.DeprecatedEcdsaFormat); err != nil {
+		rootSigner, false, app.DeprecatedEcdsaFormat); err != nil {
 		t.Fatal(err)
 	}
 
@@ -598,7 +599,7 @@ func TestConsistentSnapshotFlip(t *testing.T) {
 
 	// Sign root & targets
 	if err := app.SignCmd(ctx, stack.repoDir, []string{"root", "targets"},
-		rootSigner, app.DeprecatedEcdsaFormat); err != nil {
+		rootSigner, false, app.DeprecatedEcdsaFormat); err != nil {
 		t.Fatal(err)
 	}
 	// Sign snapshot and timestamp
@@ -660,7 +661,7 @@ func TestSignWithEcdsaHexHSM(t *testing.T) {
 	// Sign root
 	rootSigner := stack.getSigner(t, rootKeyRef)
 	if err := app.SignCmd(ctx, stack.repoDir, []string{"root"},
-		rootSigner, true); err != nil {
+		rootSigner, false, true); err != nil {
 		t.Fatal(err)
 	}
 
@@ -720,13 +721,13 @@ func TestEcdsaHexToPEMMigration(t *testing.T) {
 
 	// Just to make sure, try this with the PEM signer and expect failure
 	rootSigner := stack.getSigner(t, rootKeyRef)
-	if err := app.SignCmd(ctx, stack.repoDir, []string{"root"}, rootSigner, false); err == nil {
+	if err := app.SignCmd(ctx, stack.repoDir, []string{"root"}, rootSigner, false, false); err == nil {
 		t.Fatal("expected error signing with PEM key")
 	}
 
 	// Sign root with deprecated format signer.
 	if err := app.SignCmd(ctx, stack.repoDir, []string{"root", "targets"},
-		rootSigner, deprecatedEcdsaFormat); err != nil {
+		rootSigner, false, deprecatedEcdsaFormat); err != nil {
 		t.Fatal(err)
 	}
 
@@ -841,7 +842,7 @@ func TestEcdsaHexToPEMMigration(t *testing.T) {
 	}
 
 	// Now sign with both key types.
-	if err := app.SignCmd(ctx, stack.repoDir, []string{"root", "targets"}, rootSigner, true); err != nil {
+	if err := app.SignCmd(ctx, stack.repoDir, []string{"root", "targets"}, rootSigner, false, true); err != nil {
 		t.Fatal(err)
 	}
 
@@ -877,7 +878,7 @@ func TestSnapshotKeyRotate(t *testing.T) {
 	// Sign root & targets with key 1
 	rootSigner := stack.getSigner(t, rootKeyRef)
 	if err := app.SignCmd(ctx, stack.repoDir, []string{"root", "targets"},
-		rootSigner, app.DeprecatedEcdsaFormat); err != nil {
+		rootSigner, false, app.DeprecatedEcdsaFormat); err != nil {
 		t.Fatal(err)
 	}
 
@@ -920,7 +921,7 @@ func TestSnapshotKeyRotate(t *testing.T) {
 
 	// Sign root & targets with key 1
 	if err := app.SignCmd(ctx, stack.repoDir, []string{"root", "targets"},
-		rootSigner, app.DeprecatedEcdsaFormat); err != nil {
+		rootSigner, false, app.DeprecatedEcdsaFormat); err != nil {
 		t.Fatal(err)
 	}
 
@@ -980,7 +981,7 @@ func TestProdTargetsConfig(t *testing.T) {
 	// Sign root & targets
 	rootSigner := stack.getSigner(t, rootKeyRef)
 	if err := app.SignCmd(ctx, stack.repoDir, []string{"root", "targets"},
-		rootSigner, app.DeprecatedEcdsaFormat); err != nil {
+		rootSigner, false, app.DeprecatedEcdsaFormat); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1041,7 +1042,7 @@ func TestDelegationsClearedOnInit(t *testing.T) {
 	// Sign root & targets with key 1
 	rootSigner := stack.getSigner(t, rootKeyRef)
 	if err := app.SignCmd(ctx, stack.repoDir, []string{"root", "targets"},
-		rootSigner, app.DeprecatedEcdsaFormat); err != nil {
+		rootSigner, false, app.DeprecatedEcdsaFormat); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1059,4 +1060,67 @@ func TestDelegationsClearedOnInit(t *testing.T) {
 	if targets.Delegations != nil {
 		t.Errorf("Expected top-level targets delegations to be cleared")
 	}
+}
+
+func TestSignWithVersionBump(t *testing.T) {
+	ctx := context.Background()
+	stack := newRepoTestStack(ctx, t)
+	stack.addTarget(t, "foo.txt", "abc", nil)
+	rootKeyRef := stack.genKey(t, true)
+
+	// Initialize succeeds.
+	if err := app.InitCmd(ctx, stack.repoDir, "", 1,
+		stack.targetsConfig, stack.repoDir, stack.snapshotRef, stack.timestampRef,
+		app.DeprecatedEcdsaFormat); err != nil {
+		t.Fatal(err)
+	}
+
+	// Add a delegation
+	delegationKeyRef := stack.genKey(t, false)
+	if err := app.DelegationCmd(ctx, stack.repoDir,
+		"delegation", "path/*", true, []string{delegationKeyRef}, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	// Sign root & targets with key 1
+	rootSigner := stack.getSigner(t, rootKeyRef)
+	if err := app.SignCmd(ctx, stack.repoDir, []string{"root", "targets"},
+		rootSigner, false, app.DeprecatedEcdsaFormat); err != nil {
+		t.Fatal(err)
+	}
+	// Sign delegation
+	dSigner := stack.getSigner(t, delegationKeyRef)
+	if err := app.SignCmd(ctx, stack.repoDir, []string{"delegation"},
+		dSigner, false, app.DeprecatedEcdsaFormat); err != nil {
+		t.Fatal(err)
+	}
+
+	// Sign snapshot and timestamp
+	stack.snapshot(t, app.DeprecatedEcdsaFormat)
+	stack.timestamp(t, app.DeprecatedEcdsaFormat)
+	stack.publish(t)
+
+	if _, err := verifyTuf(t, stack.repoDir, stack.getManifest(t, "root.json")); err != nil {
+		t.Fatal(err)
+	}
+	checkMetadataVersion(t, stack.repoDir, []string{"delegation.json"}, 1)
+
+	// Increment the delegation metadata
+	if err := app.SignCmd(ctx, stack.repoDir, []string{"delegation"},
+		dSigner, true, app.DeprecatedEcdsaFormat); err != nil {
+		t.Fatal(err)
+	}
+
+	// Sign snapshot and timestamp
+	stack.snapshot(t, app.DeprecatedEcdsaFormat)
+	stack.timestamp(t, app.DeprecatedEcdsaFormat)
+	stack.publish(t)
+
+	// Verify with go-tuf
+	if _, err := verifyTuf(t, stack.repoDir, stack.getManifest(t, "root.json")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Check delegation version bump
+	checkMetadataVersion(t, stack.repoDir, []string{"delegation.json"}, 2)
 }

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -141,7 +141,7 @@ func (s *repoTestStack) snapshot(t *testing.T, deprecated bool) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := app.SignCmd(s.ctx, s.repoDir, []string{"snapshot"}, snapshotSigner, deprecated); err != nil {
+	if err := app.SignCmd(s.ctx, s.repoDir, []string{"snapshot"}, snapshotSigner, false, deprecated); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -154,7 +154,7 @@ func (s *repoTestStack) timestamp(t *testing.T, deprecated bool) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := app.SignCmd(s.ctx, s.repoDir, []string{"timestamp"}, timestampSigner, deprecated); err != nil {
+	if err := app.SignCmd(s.ctx, s.repoDir, []string{"timestamp"}, timestampSigner, false, deprecated); err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

This is to handle bumping a version of a delegation https://github.com/sigstore/root-signing/pull/410#issuecomment-1261097991 after https://github.com/sigstore/root-signing/pull/327

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->