### PR TITLE
fix: verify return exit status with error

### DIFF
--- a/cmd/verify/app/keys.go
+++ b/cmd/verify/app/keys.go
@@ -153,26 +153,23 @@ var keyCmd = &cobra.Command{
 		}
 		return nil
 	},
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		log.SetFlags(0)
 
 		rootBytes, err := os.ReadFile(rootFile.String())
 		if err != nil {
-			log.Printf("failed to read root CA file: %s", err)
-			os.Exit(1)
+			return fmt.Errorf("failed to read root CA file: %s", err)
 		}
 
 		rootCA, err := keys.ToCert(rootBytes)
 		if err != nil {
-			log.Printf("failed to parse root CA: %s", err)
-			os.Exit(1)
+			return fmt.Errorf("failed to parse root CA: %s", err)
 		}
 
 		if _, err = verifySigningKeys(keyDir.String(), rootCA); err != nil {
-			log.Printf("error verifying signing keys: %s", err)
-			os.Exit(1)
+			return fmt.Errorf("error verifying signing keys: %s", err)
 		}
-
+		return nil
 	},
 }
 

--- a/cmd/verify/app/repository.go
+++ b/cmd/verify/app/repository.go
@@ -287,29 +287,23 @@ var repositoryCmd = &cobra.Command{
 		}
 		return nil
 	},
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		log.SetFlags(0)
 
 		if !staged && root.String() == "" {
-			log.Println("must specify a trusted root file for full verification")
-			_ = cmd.Usage()
-			os.Exit(1)
+			return fmt.Errorf("must specify a trusted root file for full verification")
 		}
 
 		var validUntil *time.Time
 		if expiration != "" {
 			parsedTime, err := time.Parse("2006/01/02", expiration)
 			if err != nil {
-				log.Printf("must specify a valid time, got %s", expiration)
-				_ = cmd.Usage()
-				os.Exit(1)
+				return fmt.Errorf("must specify a valid time, got %s", expiration)
 			}
 			validUntil = &parsedTime
 		}
 
-		if err := VerifyCmd(staged, repository, root.String(), validUntil, roles); err != nil {
-			log.Println(err.Error())
-		}
+		return VerifyCmd(staged, repository, root.String(), validUntil, roles)
 	},
 }
 
@@ -353,7 +347,7 @@ func VerifyCmd(staged bool, repository string, rootFile string,
 
 	rootMeta, err := os.ReadFile(rootFile)
 	if err != nil {
-		return fmt.Errorf("error reading trusted TUF root %s: %w", root, err)
+		return fmt.Errorf("error reading trusted TUF root %s: %w", rootFile, err)
 	}
 	local := client.MemoryLocalStore()
 	if err := local.SetMeta("root.json", rootMeta); err != nil {


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

There was a missing `os.Exit(1)`: restructed to use `RunE` to avoid missing when to exit with status 1.

This will fix the prober issue of not actually failing on a verify error.
See https://github.com/sigstore/public-good-instance/actions/runs/3147659301/jobs/5117373827

Part of https://github.com/sigstore/root-signing/issues/422

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->