### PR TITLE
repository: bump revocation version after length addition

### DIFF
--- a/repository/repository/revocation.json
+++ b/repository/repository/revocation.json
@@ -1,29 +1,29 @@
 {
-	"signatures": [
-		{
-			"keyid": "9e7d813e8e16062e60a4540346aa8e7c7782afb7098af0b944ea80a4033a176f",
-			"sig": "304502205aebc2daae399b1a6941ccb62a710fc0d95564eead3a433c2e5cae11c3699abf022100b3080a43a6334a714ab29641d1796ba95c7c219ea2bf7210a608aa7ea45bbf98"
-		}
-	],
 	"signed": {
 		"_type": "targets",
-		"expires": "2023-01-18T17:33:23Z",
 		"spec_version": "1.0",
+		"version": 2,
+		"expires": "2023-01-18T17:33:23Z",
 		"targets": {
 			"revocation.list": {
+				"length": 0,
+				"hashes": {
+					"sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+					"sha512": "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"
+				},
 				"custom": {
 					"sigstore": {
 						"status": "Unknown",
 						"usage": "Unknown"
 					}
-				},
-				"hashes": {
-					"sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-					"sha512": "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"
-				},
-				"length": 0
+				}
 			}
-		},
-		"version": 1
-	}
+		}
+	},
+	"signatures": [
+		{
+			"keyid": "9e7d813e8e16062e60a4540346aa8e7c7782afb7098af0b944ea80a4033a176f",
+			"sig": "3045022100e934bb8dc2b3c9089f5e8f4ec0038b856be09f5871cf54133285f09946ce9e840220282dc45c462a9ac60314fa2776247f84b4616823f6c01910be4307df694a1f42"
+		}
+	]
 }

--- a/repository/repository/snapshot.json
+++ b/repository/repository/snapshot.json
@@ -2,8 +2,8 @@
 	"signed": {
 		"_type": "snapshot",
 		"spec_version": "1.0",
-		"version": 49,
-		"expires": "2022-10-17T20:31:40Z",
+		"version": 50,
+		"expires": "2022-10-24T16:40:00Z",
 		"meta": {
 			"rekor.json": {
 				"length": 797,
@@ -16,10 +16,10 @@
 			"revocation.json": {
 				"length": 800,
 				"hashes": {
-					"sha256": "fd46a3ad04afd31e164b91d5d399d3e6e4d22e1c98ad463aeca0fa3d2f8cb6dd",
-					"sha512": "6cacdb83edac8283bcbf6e4d7011f98ae85f05c22034e4466de96496739df224d8a9fd580abfc3e4d4901e2170dbe0d93865a1e861bf85556e03f36d00cc5b5b"
+					"sha256": "6f60848ba8fb0955a02abfd1232fb3845dc9ee9f418bf03521a7ddb48217e040",
+					"sha512": "a965dddd0d0edef6c59e84cf02ecf5a53299f633fd339b2b61814a4219ab4df672a6390f265b8b29e1c8cea9368ea3440df013790759d50231a30df1c1f02551"
 				},
-				"version": 1
+				"version": 2
 			},
 			"root.json": {
 				"length": 5297,
@@ -50,7 +50,7 @@
 	"signatures": [
 		{
 			"keyid": "fc61191ba8a516fe386c7d6c97d918e1d241e1589729add09b122725b8c32451",
-			"sig": "304602210081504cb1d475038cf1be5c23eb12f67da4683c11f8954be01c371d74a376b062022100b6062810c0f01bd2081e79b65bc625cdfc60c441e97538708ded69b790f70595"
+			"sig": "3045022100b91732f5ea0c105ecf309f212845e768088cac7da41e4f0e38fdcf76bea43135022008bb9bce4c2059a55833852ddbacb6f3a8401e5adb21ebde8b97a2617151618f"
 		}
 	]
 }

--- a/repository/repository/timestamp.json
+++ b/repository/repository/timestamp.json
@@ -2,23 +2,23 @@
 	"signed": {
 		"_type": "timestamp",
 		"spec_version": "1.0",
-		"version": 49,
-		"expires": "2022-10-10T20:31:41Z",
+		"version": 50,
+		"expires": "2022-10-17T16:40:11Z",
 		"meta": {
 			"snapshot.json": {
-				"length": 1977,
+				"length": 1975,
 				"hashes": {
-					"sha256": "9967748df460243463d8ceeb3540f68a5669f6a9f76ec75d730c5daf60b77be3",
-					"sha512": "20c00db65b03f9282b5cbb917cf2d658a0cc3a8145c09b3ea95348e668b70a1d4acb50c5cc59155476b010e92ca1fc1f13386fcf278896f39e5f219b3ae7fcf9"
+					"sha256": "a16b42684e028b43b5e99400f2b30e8776f9b7705a190a3174849bac1d84712f",
+					"sha512": "feb99282e4a1c116fa6e6429847b5e2ccda72a24ed786c1d018c9ad1d1896e521dee4603e6a12f2a199c051485a68e5915f72160a3389c82d133fa7212eb8917"
 				},
-				"version": 49
+				"version": 50
 			}
 		}
 	},
 	"signatures": [
 		{
 			"keyid": "b6710623a30c010738e64c5209d367df1c0a18cf90e6ab5292fb01680f83453d",
-			"sig": "3045022038fbfba9d126c5aeed75c8a422cf6542ee5c8fa4625bb95d9753840a60f4ff49022100a33f8f215d1e3f4ec396315857b5a12703fab119257f7dcc905a021c97c05c24"
+			"sig": "304502204cea02aecb1d736c18490434e4de01d6e55b16b6371c1a7575fd48050fc4d795022100c55f2547cb639e55bf2d528ad79b6be43d97f92f96dd6fc398ecc60246818c79"
 		}
 	]
 }


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

https://github.com/sigstore/root-signing/pull/410#issuecomment-1261097991

Before the new root signing event, we should close out this erroneous lack of version update in the revocation delegation.

The delegation had updated payload for compatibility with rust here: https://github.com/sigstore/root-signing/pull/327

and should have increased in version.

To produce this change, I had to run
```
$ export GITHUB_USER=asraa
$ export LOCAL=1
$ ./scripts/step-0.sh
$ ./tuf sign -repository $REPO -roles revocation -key ${REVOCATION_KEY} -add-deprecated=true -bump-version=true
Signing metadata for revocation.json... 
$ ./tuf snapshot -repository /home/asraa/git/root-signing/repository
$ ./tuf sign -repository /home/asraa/git/root-signing/repository -roles snapshot -key gcpkms://projects/project-rekor/locations/global/keyRings/sigstore-root/cryptoKeys/snapshot -add-deprecated=true
Signing metadata for snapshot.json... 
$ ./tuf timestamp -repository "$REPO"
$ ./tuf sign -repository "$REPO" -roles timestamp -key "${TIMESTAMP_KEY}" -add-deprecated=true
Signing metadata for timestamp.json... 
$ ./tuf publish -repository $REPO
Metadata successfully validated!
```

