### PR TITLE
Add new TUF keyids to keyholder list

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@ The pre-production root is published on a GCS bucket located at `https://storage
 
 | Keyholder        |  TUF Key ID |  Yubikey Material| Term | 
 | ----- |--------- |  --- | ---- |
-| Joshua Lock       |  `75e867ab10e121fdef32094af634707f43ddd79c6bab8ad6c5ab9f03f4ea8c90` | [18158855](https://github.com/sigstore/root-signing/ceremony/2022-07-12/keys/18158855)  | July 2022 -  | 
-| Bob Callaway        |  `f505595165a177a41750a8e864ed1719b1edfccd5a426fd2c0ffda33ce7ff209` | [15938791](https://github.com/sigstore/root-signing/tree/main/ceremony/2021-06-18/keys/15938791)  | June 2021 -  | 
-| Dan Lorenc        |  `2f64fb5eac0cf94dd39bb45308b98920055e9a0d8e012a7220787834c60aef97` | [13078778](https://github.com/sigstore/root-signing/tree/main/ceremony/2021-06-18/keys/13078778)  | June 2021 -  | 
-| Marina Moore        |  `eaf22372f417dd618a46f6c627dbc276e9fd30a004fc94f9be946e73f8bd090b` | [14470876](https://github.com/sigstore/root-signing/tree/main/ceremony/2021-06-18/keys/14470876)  | June 2021 -  | 
-| Santiago Torres-Arias        |  `f40f32044071a9365505da3d1e3be6561f6f22d0e60cf51df783999f6c3429cb` | [15938765](https://github.com/sigstore/root-signing/tree/main/ceremony/2021-06-18/keys/15938765) | June 2021 -  | 
+| Joshua Lock       |  `2e61cd0cbf4a8f45809bda9f7f78c0d33ad11842ff94ae340873e2664dc843de` (new, v5+) `75e867ab10e121fdef32094af634707f43ddd79c6bab8ad6c5ab9f03f4ea8c90` (deprecated) | [18158855](https://github.com/sigstore/root-signing/tree/main/ceremony/2022-07-12/keys/18158855)  | July 2022 -  |
+| Bob Callaway        |  `7f7513b25429a64473e10ce3ad2f3da372bbdd14b65d07bbaf547e7c8bbbe62b` (new, v5+) `f505595165a177a41750a8e864ed1719b1edfccd5a426fd2c0ffda33ce7ff209` (deprecated) | [15938791](https://github.com/sigstore/root-signing/tree/main/ceremony/2021-06-18/keys/15938791)  | June 2021 -  |
+| Dan Lorenc        |  `ff51e17fcf253119b7033f6f57512631da4a0969442afcf9fc8b141c7f2be99c` (new, v5+) `2f64fb5eac0cf94dd39bb45308b98920055e9a0d8e012a7220787834c60aef97` (deprecated) | [13078778](https://github.com/sigstore/root-signing/tree/main/ceremony/2021-06-18/keys/13078778)  | June 2021 -  |
+| Marina Moore        |  `25a0eb450fd3ee2bd79218c963dce3f1cc6118badf251bf149f0bd07d5cabe99` (new, v5+) `eaf22372f417dd618a46f6c627dbc276e9fd30a004fc94f9be946e73f8bd090b` (deprecated) | [14470876](https://github.com/sigstore/root-signing/tree/main/ceremony/2021-06-18/keys/14470876)  | June 2021 -  |
+| Santiago Torres-Arias        | `f5312f542c21273d9485a49394386c4575804770667f2ddb59b3bf0669fddd2f` (new, v5+) `f40f32044071a9365505da3d1e3be6561f6f22d0e60cf51df783999f6c3429cb` (deprecated) | [15938765](https://github.com/sigstore/root-signing/tree/main/ceremony/2021-06-18/keys/15938765) | June 2021 -  |
 
 ### Emeritus Keyholders
 | Keyholder        |  TUF Key ID |  Yubikey Material| Term | 


### PR DESCRIPTION
Update the keyholders list in the README to include the TUF keyids for the new key formats introduced in the v5 ceremony.

We continue to list the old TUF keyids for now as they help explain the continuity from v4 to v5 (it's the same key materials, just different key formats and keyids).

Signed-off-by: Joshua Lock <jlock@vmware.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->