### PR TITLE
ci: add reusable workflow for configuring snapshot and timestamp

### DIFF
--- a/.github/workflows/reuseable-snapshot-timestamp.yml
+++ b/.github/workflows/reuseable-snapshot-timestamp.yml
@@ -13,24 +13,34 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Snapshot and Timestamp
+name: Snapshot and Timestamp Template
 
-permissions: read-all
-
-# Execute this as a biweekly cron job and on changes to repository/
-# when new published metadata is submitted.
+# Reusable workflow that runs snapshot and timestamp on directories.
+# TODO(asraa): Create user workflows for repository-beta/, and ceremony/ flows.
 on:
-  # Enable cron for re-signing snapshot and timestamp every week
-  schedule:
-    - cron: '0 0 */7 * *' # every 7 days
-  # When a new root is staged
-  push:
-    branches:
-      - main
-    paths:
-      - 'repository/staged/root.json'
-  workflow_dispatch:
+  workflow_call:
     inputs:
+      snapshot_key:
+        description: 'Sets the snapshotting key reference'
+        required: true
+        type: string
+      timestamp_key:
+        description: 'Sets the timestamping key reference'
+        required: true
+        type: string
+      repo:
+        description: 'Sets the repository to perform the operation on: expects relative path to GitHub repository, for example: ceremony/2022-10-03'
+        required: false
+        default: repository/
+        type: string
+      provider:
+        description: 'Sets the workflow identity provider'
+        required: true
+        type: string
+      service_account:
+        description: 'Sets the GitHub service account authorized for keys'
+        required: true
+        type: string
       snapshot_timestamp:
         description: 'Enables snapshot/timestamp step. During ceremonies, you may flip this to false to allow for just a publish step.'
         required: false
@@ -41,11 +51,6 @@ on:
         required: false
         default: true
         type: bool
-      repo:
-        description: 'Sets the repository to perform the operation on: expects relative path to GitHub repository, for example: ceremony/2022-10-03'
-        required: false
-        default: repository/
-        type: string
 
 jobs:
   snapshot_and_timestamp:
@@ -60,8 +65,8 @@ jobs:
         run: |
           echo "GITHUB_USER=${{ github.actor }}" >> $GITHUB_ENV
           echo "REPO=$(pwd)/${{ inputs.repo }}" >> $GITHUB_ENV
-          echo "SNAPSHOT_KEY=gcpkms://projects/sigstore-root-signing/locations/global/keyRings/root/cryptoKeys/snapshot" >> $GITHUB_ENV
-          echo "TIMESTAMP_KEY=gcpkms://projects/sigstore-root-signing/locations/global/keyRings/root/cryptoKeys/timestamp" >> $GITHUB_ENV
+          echo "SNAPSHOT_KEY={{ inputs.snapshot_key }}" >> $GITHUB_ENV
+          echo "TIMESTAMP_KEY={{ inputs.timestamp_key }}" >> $GITHUB_ENV
           # Note: we set LOCAL=1 because we manually push the changes in the next job.
           echo "LOCAL=1" >> $GITHUB_ENV
       - uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f # v2.2.0
@@ -75,8 +80,8 @@ jobs:
         id: auth
         with:
           token_format: 'access_token'
-          workload_identity_provider: 'projects/163070369698/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider'
-          service_account: 'github-actions@sigstore-root-signing.iam.gserviceaccount.com'
+          workload_identity_provider: ${{ inputs.provider }}
+          service_account: ${{ inputs.service_account }}
           create_credentials_file: true
       - name: Login
         run: |
@@ -114,6 +119,7 @@ jobs:
       issues: 'write'
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      ISSUE_REPOSITORY: sigstore/root-signing
     if: always() && needs.snapshot_and_timestamp.result == 'failure'
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
@@ -153,6 +159,7 @@ jobs:
       issues: 'write'
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      ISSUE_REPOSITORY: sigstore/root-signing
     if: always() && needs.push.result == 'failure'
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0

--- a/.github/workflows/stable-snapshot-timestamp.yml
+++ b/.github/workflows/stable-snapshot-timestamp.yml
@@ -1,0 +1,49 @@
+#
+# Copyright 2021 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Stable Snapshot and Timestamp
+
+permissions: read-all
+
+# Execute this as a biweekly cron job and on changes to repository/
+# when new published metadata is submitted.
+on:
+  # Enable cron for re-signing snapshot and timestamp every week
+  schedule:
+    - cron: '0 0 */7 * *' # every 7 days
+  # When a new root is staged
+  push:
+    branches:
+      - main
+    paths:
+      - 'repository/staged/root.json'
+  workflow_dispatch:
+
+jobs:
+  run_snapshot_timestamp_publish:
+    runs-on: ubuntu-20.04
+    permissions:
+      id-token: 'write'
+      issues: 'write'
+      pull-requests: 'write'
+      contents: 'write'
+    steps:
+      - uses: sigstore/root-signing/.github/workflows/reuseable-snapshot-timestamp.yml@main
+        with:
+          snapshot_key: 'gcpkms://projects/project-rekor/locations/global/keyRings/sigstore-root/cryptoKeys/snapshot'
+          timestamp_key: 'gcpkms://projects/project-rekor/locations/global/keyRings/sigstore-root/cryptoKeys/timestamp'
+          repo: 'repository/'
+          provider: projects/237800849078/locations/global/workloadIdentityPools/root-signing-pool/providers/sigstore-root'
+          service_account: 'sigstore-root-signing@project-rekor.iam.gserviceaccount.com'


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

This adds a new reusable workflow for running snapshot and timestamp.

This then adds the production signing job with the production config in `stable-snapshot-timestamp.yml`.

I will test this, and add a follow-up later when we decide to fork repositories or not. But this generally clears things up so I can have INDEPENDENT flows for snapshot-timestamp.yml on (1) prod (2) beta roots and (3) staged ceremonies. 

Supersedes https://github.com/sigstore/root-signing/pull/449

cc @jku 

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->