### PR TITLE
fix: fix reusable workflow syntax and add ci job

### DIFF
--- a/.github/workflows/reuseable-snapshot-timestamp.yml
+++ b/.github/workflows/reuseable-snapshot-timestamp.yml
@@ -45,12 +45,12 @@ on:
         description: 'Enables snapshot/timestamp step. During ceremonies, you may flip this to false to allow for just a publish step.'
         required: false
         default: true
-        type: bool
+        type: boolean
       publish:
         description: 'Enables publishing step. During ceremonies, you may flip this to false to allow for reviewing changes before publishing.'
         required: false
         default: true
-        type: bool
+        type: boolean
 
 jobs:
   snapshot_and_timestamp:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,10 +67,10 @@ jobs:
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
       - name: Check workflow files
-        uses: docker://rhysd/actionlint:1.6.20
+        uses: reviewdog/action-actionlint@8ce1a5c1df6c19443f6edfaffa97c781833f3039 # v1.32.0
         # TODO(asraa): Re-enable shellcheck from actionlint
         with:
-          args: -color -shellcheck=
+          actionlint_flags: -color -shellcheck=
 
   test:
     runs-on: ubuntu-20.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,6 +62,15 @@ jobs:
           # Run yamllint
           make yamllint
 
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+      - name: Check workflow files
+        uses: docker://rhysd/actionlint:1.6.20
+        with:
+          args: -color
+
   test:
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,8 +68,9 @@ jobs:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
       - name: Check workflow files
         uses: docker://rhysd/actionlint:1.6.20
+        # TODO(asraa): Re-enable shellcheck from actionlint
         with:
-          args: -color
+          args: -color -shellcheck=
 
   test:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

It turns out `actionlint` has a docker image that we can run during CI! Phew.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->