### PR TITLE
snapshot: add back deprecated keys for snapshotting

### DIFF
--- a/.github/workflows/scripts/report-failure.sh
+++ b/.github/workflows/scripts/report-failure.sh
@@ -42,12 +42,12 @@ EOF
 THIS_FILE=$(this_file)
 create_issue_body
 
-ISSUE_ID=$(gh -R "$ISSUE_REPOSITORY" issue list --label "type:bug" --state open -S "$THIS_FILE" --json number | jq '.[0]' | jq -r '.number' | jq 'select (.!=null)')
+ISSUE_ID=$(gh -R "$ISSUE_REPOSITORY" issue list --label "bug" --state open -S "$THIS_FILE" --json number | jq '.[0]' | jq -r '.number' | jq 'select (.!=null)')
 
 if [[ -z "$ISSUE_ID" ]]; then
     # Replace `-`` by ` `, remove the last 4 characters `.yml`. Expected: "snapshot timestamp".
     TITLE=$(echo "$THIS_FILE" | sed -e 's/\-/ /g' | rev | cut -c5- | rev)
-    GH_TOKEN=$GITHUB_TOKEN gh -R "$ISSUE_REPOSITORY" issue create -t "[bug]: Updating workflow $TITLE" -F ./BODY --label "type:bug"
+    GH_TOKEN=$GITHUB_TOKEN gh -R "$ISSUE_REPOSITORY" issue create -t "[bug]: Updating workflow $TITLE" -F ./BODY --label "bug"
 else
     GH_TOKEN=$GITHUB_TOKEN gh -R "$ISSUE_REPOSITORY" issue comment "$ISSUE_ID" -F ./BODY
 fi

--- a/scripts/step-3.sh
+++ b/scripts/step-3.sh
@@ -45,10 +45,10 @@ checkout_branch
 
 # Snapshot and sign the snapshot with snapshot kms key
 ./tuf snapshot -repository "$REPO"
-./tuf sign -repository "$REPO" -roles snapshot -key "${SNAPSHOT_KEY}"
+./tuf sign -repository "$REPO" -roles snapshot -key "${SNAPSHOT_KEY}" -add-deprecated=true
 
 # Timestamp and sign the timestamp with timestamp kms key
 ./tuf timestamp -repository "$REPO"
-./tuf sign -repository "$REPO" -roles timestamp -key "${TIMESTAMP_KEY}"
+./tuf sign -repository "$REPO" -roles timestamp -key "${TIMESTAMP_KEY}" -add-deprecated=true
 
 commit_and_push_changes snapshot-timestamp


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

2. This manual run https://github.com/sigstore/root-signing/actions/runs/3228907303/jobs/5285594842#step:9:64
 
showed this error:
```
+ ./tuf sign -repository /home/runner/work/root-signing/root-signing/repository/ -roles snapshot -key gcpkms://projects/project-rekor/locations/global/keyRings/sigstore-root/cryptoKeys/snapshot
Signing metadata for snapshot.json... 
error: expected key IDs  for metadata role snapshot.json, got map[fc[61](https://github.com/sigstore/root-signing/actions/runs/3228907303/jobs/5285594842#step:9:62)191ba8a516fe386c7d6c97d918e1d241e1589729add09b122725b8c32451:true]
```

which indicates that the deprecated key format was not added to the list of key IDs to add signatures to.

2. Report failure failed on finding the label `type:bug`. It was actually just requiring a `bug`: Tested this with my local `gh` API request:
```
$ gh -R sigstore/root-signing issue list --label "bug" --state open

Showing 6 of 6 issues in sigstore/root-signing that match your search
```



<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->