### PR TITLE
ci: use separate commits for repository and staged

### DIFF
--- a/.github/workflows/staging-initialize.yml
+++ b/.github/workflows/staging-initialize.yml
@@ -115,6 +115,17 @@ jobs:
           VERSION=$(cat ceremony/${DATE}/staged/root.json | jq -r '.signed.version')
           echo "VERSION=$VERSION" >> $GITHUB_ENV
 
+      # Create commits
+      - name: Create commits
+        run: |
+          # First commit the old repository data.
+          git add ceremony/"${DATE}"/repository/ ceremony/"${DATE}"/keys/
+          git commit -s -m "Copy current repository metadata and keys"
+
+          # Now put the staged metadata into a second commit
+          git add ceremony/"${DATE}"/staged/
+          git commit -s -m "Add staged repository metadata"
+
       # Open pull request changes
       - name: create pull request
         uses: peter-evans/create-pull-request@ad43dccb4d726ca8514126628bec209b8354b6dd # v4.1.3

--- a/.github/workflows/staging-initialize.yml
+++ b/.github/workflows/staging-initialize.yml
@@ -131,7 +131,7 @@ jobs:
         uses: peter-evans/create-pull-request@ad43dccb4d726ca8514126628bec209b8354b6dd # v4.1.3
         with:
           commit-message: update root and targets
-          title: Update Root and Targets to ${{ env.VERSION }}
+          title: Update Root and Targets to version ${{ env.VERSION }}
           body: Initializes a new root and targets to version ${{ env.VERSION }}
           branch: init-root-targets
           signoff: true


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

As you know, reviewing a new root/targets is really annoying because it commits 50 files that include the OLD metadata.

This separates the two commits added so that the repository data and keys are in a separate commit as the staged metadata (and targets), allowing reviewers to toggle which commit they want to view changes for.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->