### PR TITLE
ci: fix github identity config for commits

### DIFF
--- a/.github/workflows/staging-initialize.yml
+++ b/.github/workflows/staging-initialize.yml
@@ -118,6 +118,10 @@ jobs:
       # Create commits
       - name: Create commits
         run: |
+          # Set identity.
+          git config --global user.email "noreply@github.com"
+          git config --global user.name "GitHub"
+
           # First commit the old repository data.
           git add ceremony/"${DATE}"/repository/ ceremony/"${DATE}"/keys/
           git commit -s -m "Copy current repository metadata and keys"


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Workflows don't have git identity configured:
```
Author identity unknown

*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.
```
https://github.com/sigstore/root-signing/actions/runs/3268036964/jobs/5374008102

This matches the identity here: https://github.com/sigstore/root-signing/pull/478/commits/fcfffae7652249858bcae1651c63bd6700f43e39

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->