### PR TITLE
ci: pass through inputs from staging snapshot workflow to reusable workflow

### DIFF
--- a/.github/workflows/staging-snapshot-timestamp.yml
+++ b/.github/workflows/staging-snapshot-timestamp.yml
@@ -36,7 +36,7 @@ jobs:
     with:
       snapshot_key: 'gcpkms://projects/sigstore-root-signing/locations/global/keyRings/root/cryptoKeys/snapshot'
       timestamp_key: 'gcpkms://projects/sigstore-root-signing/locations/global/keyRings/root/cryptoKeys/timestamp'
-      repo: 'repository/'
+      repo: ${{ inputs.repo }}
       provider: 'projects/163070369698/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider'
       service_account: 'github-actions@sigstore-root-signing.iam.gserviceaccount.com'
       publish: false


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

I was debugging https://github.com/sigstore/root-signing/actions/runs/3292777546/jobs/5428542203 (and panicing!) and realized debug logs set up the `repo` with `repository/`, the default:
```
  echo "REPO=$(pwd)/repository/" >> $GITHUB_ENV
```

Then noticed that I never passed the workflow input (staging ceremony) into the reusable workflow.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->