### PR TITLE
Update python-tuf tests for v5 root

### DIFF
--- a/.github/workflows/tuf_client_tests.yml
+++ b/.github/workflows/tuf_client_tests.yml
@@ -66,7 +66,6 @@ jobs:
             -t http://localhost:8001/targets \
             -m http://localhost:8001
       # Test with python-tuf ngclient
-      - continue-on-error: true # remove once v5 root is published
-        run: |
+      - run: |
           python3 -m pip install securesystemslib[crypto,pynacl] tuf
           python3 tests/client-tests/python-tuf.py

--- a/scripts/step-4.sh
+++ b/scripts/step-4.sh
@@ -39,7 +39,7 @@ checkout_branch
 # Clear and copy into the repository/
 TEMP_REPO="$(mktemp -d)"
 cp -r "$REPO"/ "$TEMP_REPO"
-rm -r repository/
+rm -r repository/*
 cp -r "$TEMP_REPO"/* repository/
 
 commit_and_push_changes publish

--- a/tests/client-tests/python-tuf.py
+++ b/tests/client-tests/python-tuf.py
@@ -35,6 +35,8 @@ with tempfile.TemporaryDirectory() as tmpdirname:
         "repository/repository/5.root.json",
         f"{METADATA_DIR}/root.json")
 
+    # TODO: we hard-code a single target here and will need to update this
+    # if the target retrieval API changes.
     fulcio_cert = "fulcio.crt.pem"
     try:
         updater = Updater(

--- a/tests/client-tests/python-tuf.py
+++ b/tests/client-tests/python-tuf.py
@@ -15,6 +15,7 @@
 
 import os
 import shutil
+import sys
 import tempfile
 
 from tuf.ngclient import Updater
@@ -34,9 +35,24 @@ with tempfile.TemporaryDirectory() as tmpdirname:
         "repository/repository/4.root.json",
         f"{METADATA_DIR}/root.json")
 
-    updater = Updater(
-        metadata_dir=METADATA_DIR,
-        metadata_base_url=f"{REPO_URL}/metadata/",
-        target_base_url=f"{REPO_URL}/targets/",
-        target_dir=tmpdirname)
-    updater.refresh()
+    fulcio_cert = "fulcio.crt.pem"
+    try:
+        updater = Updater(
+            metadata_dir=METADATA_DIR,
+            metadata_base_url=f"{REPO_URL}",
+            target_base_url=f"{REPO_URL}/targets/",
+            target_dir=tmpdirname)
+        updater.refresh()
+
+        info = updater.get_targetinfo(fulcio_cert)
+
+        if info is None:
+            print(f"Failed to fetch {fulcio_cert}")
+            sys.exit(1)
+
+        path = updater.download_target(info)
+        print(f"Fetched {fulcio_cert} to {path}")
+
+    except:
+        print(f"Updated and fetch of {fulcio_cert} failed")
+        sys.exit(2)

--- a/tests/client-tests/python-tuf.py
+++ b/tests/client-tests/python-tuf.py
@@ -26,13 +26,13 @@ with tempfile.TemporaryDirectory() as tmpdirname:
     METADATA_DIR = f"{tmpdirname}/metadata"
     os.mkdir(METADATA_DIR)
 
-    # Copy in root metadata to use as trusted root
-    # NOTE: we have to use v5 or newer, once it exists, because prior versions
-    # were not compatible with python-tuf:
+    # Copy in root metadata to use as trusted root.
+    # NOTE: we have to use v5 or newer because prior versions were not
+    # compatible with python-tuf:
     # https://github.com/sigstore/root-signing/issues/103
     # https://github.com/sigstore/root-signing/issues/329
     shutil.copyfile(
-        "repository/repository/4.root.json",
+        "repository/repository/5.root.json",
         f"{METADATA_DIR}/root.json")
 
     fulcio_cert = "fulcio.crt.pem"

--- a/tests/client-tests/python-tuf.py
+++ b/tests/client-tests/python-tuf.py
@@ -42,7 +42,6 @@ with tempfile.TemporaryDirectory() as tmpdirname:
             metadata_base_url=f"{REPO_URL}",
             target_base_url=f"{REPO_URL}/targets/",
             target_dir=tmpdirname)
-        updater.refresh()
 
         info = updater.get_targetinfo(fulcio_cert)
 
@@ -53,6 +52,7 @@ with tempfile.TemporaryDirectory() as tmpdirname:
         path = updater.download_target(info)
         print(f"Fetched {fulcio_cert} to {path}")
 
-    except:
+    except Exception as e:
         print(f"Updated and fetch of {fulcio_cert} failed")
+        print(e)
         sys.exit(2)


### PR DESCRIPTION
**NOTE:** opened as draft until v5 root is fully operational.

This PR does the following
* Makes a minor change to scripts/step-4.sh to allow it to run without issue on macOS with zsh
* Updates the python-tuf client test to retrieve a target once metadata has been updated
* Updates the python-tuf client test to bootstrap from the v5 root
* Removes `continue-on-error` from the python-tuf step in .github/workflows/tuf_client_tests.yml

Closes #346 
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->