### PR TITLE
test: fix go-tuf client tests to support both key types

### DIFF
--- a/.github/workflows/tuf_client_tests.yml
+++ b/.github/workflows/tuf_client_tests.yml
@@ -44,10 +44,16 @@ jobs:
         with:
           go-version: '1.18.x'
       - run: |
-          go install github.com/theupdateframework/go-tuf/cmd/tuf-client@v0.4.0
+          go install github.com/theupdateframework/go-tuf/cmd/tuf-client@v0.5.1
       - run: |
-          tuf-client init http://localhost:8001 repository/repository/1.root.json
-          tuf-client list http://localhost:8001
+          # Only 5.root.json is compatible with new versions of go-tuf
+          if [ -f repository/repository/5.root.json ]; then
+            tuf-client init http://localhost:8001 repository/repository/5.root.json
+            tuf-client list http://localhost:8001
+          fi
+          # Verify with a go-tuf client that can understand deprecated keys
+          go run ./tests/client-tests init http://localhost:8001 repository/repository/1.root.json
+          go run ./tests/client-tests list http://localhost:8001
       # Test with rust client
       - name: Install tuftool
         uses: actions-rs/install@9da1d2adcfe5e7c16992e8242ca33a56b6d9b101 # v0.1.2

--- a/go.mod
+++ b/go.mod
@@ -52,9 +52,10 @@ require (
 	github.com/docker/distribution v2.8.1+incompatible // indirect
 	github.com/docker/docker v20.10.17+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.6.4 // indirect
-	github.com/dustin/go-humanize v1.0.0 // indirect
+	github.com/dustin/go-humanize v1.0.0
 	github.com/envoyproxy/go-control-plane v0.10.2-0.20220325020618-49ff273808a1 // indirect
 	github.com/envoyproxy/protoc-gen-validate v0.6.2 // indirect
+	github.com/flynn/go-docopt v0.0.0-20140912013429-f6dd2ebbb31e
 	github.com/fsnotify/fsnotify v1.5.4 // indirect
 	github.com/fullstorydev/grpcurl v1.8.7 // indirect
 	github.com/go-chi/chi v4.1.2+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -374,6 +374,8 @@ github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGE
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
+github.com/flynn/go-docopt v0.0.0-20140912013429-f6dd2ebbb31e h1:Ss/B3/5wWRh8+emnK0++g5zQzwDTi30W10pKxKc4JXI=
+github.com/flynn/go-docopt v0.0.0-20140912013429-f6dd2ebbb31e/go.mod h1:HyVoz1Mz5Co8TFO8EupIdlcpwShBmY98dkT2xeHkvEI=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=

--- a/tests/client-tests/main.go
+++ b/tests/client-tests/main.go
@@ -68,10 +68,10 @@ List available target files.
 		if len(cmdArgs) == 0 { // `tuf-client help`
 			fmt.Fprint(os.Stdout, usage)
 			return
-		} else { // `tuf-client help <command>`
-			cmd = cmdArgs[0]
-			cmdArgs = []string{"--help"}
 		}
+		// `tuf-client help <command>`
+		cmd = cmdArgs[0]
+		cmdArgs = []string{"--help"}
 	}
 
 	if err := runCommand(cmd, cmdArgs); err != nil {

--- a/tests/client-tests/main.go
+++ b/tests/client-tests/main.go
@@ -1,0 +1,167 @@
+//
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// NOTE: This is mostly a copy of the go-tuf client, but with deprecated ECSDA
+// support in order to provide full verification of old and new formatted keys.
+// See https://github.com/theupdateframework/go-tuf/blob/master/cmd/tuf-client
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"text/tabwriter"
+
+	"github.com/dustin/go-humanize"
+	docopt "github.com/flynn/go-docopt"
+	tuf "github.com/theupdateframework/go-tuf/client"
+	tuf_leveldbstore "github.com/theupdateframework/go-tuf/client/leveldbstore"
+	_ "github.com/theupdateframework/go-tuf/pkg/deprecated/set_ecdsa"
+)
+
+func main() {
+	log.SetFlags(0)
+
+	usage := `usage: tuf-client [-h|--help] <command> [<args>...]
+Options:
+  -h, --help
+Commands:
+  help         Show usage for a specific command
+  init         Initialize with root keys
+  list         List available target files
+  get          Get a target file
+See "tuf-client help <command>" for more information on a specific command.
+`
+	register("init", cmdInit, `
+usage: tuf-client init [-s|--store=<path>] <url> [<root-metadata-file>]
+Options:
+  -s <path>    The path to the local file store [default: tuf.db]
+Initialize the local file store with root metadata.
+  `)
+
+	register("list", cmdList, `
+usage: tuf-client list [-s|--store=<path>] <url>
+Options:
+  -s <path>    The path to the local file store [default: tuf.db]
+List available target files.
+	`)
+
+	args, _ := docopt.Parse(usage, nil, true, "", true)
+	cmd := args.String["<command>"]
+	cmdArgs := args.All["<args>"].([]string)
+
+	if cmd == "help" {
+		if len(cmdArgs) == 0 { // `tuf-client help`
+			fmt.Fprint(os.Stdout, usage)
+			return
+		} else { // `tuf-client help <command>`
+			cmd = cmdArgs[0]
+			cmdArgs = []string{"--help"}
+		}
+	}
+
+	if err := runCommand(cmd, cmdArgs); err != nil {
+		log.Fatalln("ERROR:", err)
+	}
+}
+
+type cmdFunc func(*docopt.Args, *tuf.Client) error
+
+type command struct {
+	usage string
+	f     cmdFunc
+}
+
+var commands = make(map[string]*command)
+
+func register(name string, f cmdFunc, usage string) {
+	commands[name] = &command{usage: usage, f: f}
+}
+
+func runCommand(name string, args []string) error {
+	argv := make([]string, 1, 1+len(args))
+	argv[0] = name
+	argv = append(argv, args...)
+
+	cmd, ok := commands[name]
+	if !ok {
+		return fmt.Errorf("%s is not a tuf-client command. See 'tuf-client help'", name)
+	}
+
+	parsedArgs, err := docopt.Parse(cmd.usage, argv, true, "", true)
+	if err != nil {
+		return err
+	}
+
+	client, err := tufClient(parsedArgs)
+	if err != nil {
+		return err
+	}
+	return cmd.f(parsedArgs, client)
+}
+
+func tufClient(args *docopt.Args) (*tuf.Client, error) {
+	store, ok := args.String["--store"]
+	if !ok {
+		store = args.String["-s"]
+	}
+	local, err := tuf_leveldbstore.FileLocalStore(store)
+	if err != nil {
+		return nil, err
+	}
+	remote, err := tuf.HTTPRemoteStore(args.String["<url>"], nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return tuf.NewClient(local, remote), nil
+}
+
+func cmdInit(args *docopt.Args, client *tuf.Client) error {
+	file := args.String["<root-metadata-file>"]
+	var in io.Reader
+	if file == "" || file == "-" {
+		in = os.Stdin
+	} else {
+		var err error
+		in, err = os.Open(file)
+		if err != nil {
+			return err
+		}
+	}
+	bytes, err := io.ReadAll(in)
+	if err != nil {
+		return err
+	}
+	return client.Init(bytes)
+}
+
+func cmdList(args *docopt.Args, client *tuf.Client) error {
+	if _, err := client.Update(); err != nil {
+		return err
+	}
+	targets, err := client.Targets()
+	if err != nil {
+		return err
+	}
+	w := tabwriter.NewWriter(os.Stdout, 1, 2, 2, ' ', 0)
+	defer w.Flush()
+	fmt.Fprintln(w, "PATH\tSIZE")
+	for path, meta := range targets {
+		fmt.Fprintf(w, "%s\t%s\n", path, humanize.Bytes(uint64(meta.Length)))
+	}
+	return nil
+}


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

See https://github.com/sigstore/root-signing/pull/512 for the CI failure.

This adds a lightweight go-tuf client that also imports deprecated key support. This way we can test go-tuf clients from 1.root.json to 5.root.json, and use the new go-tuf version for 5.root.json+

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->