### PR TITLE
Don't run cron workflows in forks

### DIFF
--- a/.github/workflows/stable-snapshot-timestamp.yml
+++ b/.github/workflows/stable-snapshot-timestamp.yml
@@ -33,6 +33,7 @@ on:
 
 jobs:
   run_snapshot_timestamp_publish:
+    if: (github.event_name == 'schedule' && github.repository == 'sigstore/root-signing') || (github.event_name != 'schedule')  # Don't run workflow in forks on cron
     permissions:
       id-token: 'write'
       issues: 'write'

--- a/.github/workflows/sync_to_prod.yml
+++ b/.github/workflows/sync_to_prod.yml
@@ -28,6 +28,7 @@ on:
 
 jobs:
   sync:
+    if: (github.event_name == 'schedule' && github.repository == 'sigstore/root-signing') || (github.event_name != 'schedule')  # Don't run workflow in forks on cron
     runs-on: ubuntu-20.04
     permissions:
       id-token: 'write'


### PR DESCRIPTION
When creating a fork (due to new TUF root veryifing, among others) and not deleting it after, the cron-scheduled actions would run on the fork but break due to missing credentials (e.g., [1](https://github.com/mihaimaruseac/root-signing/actions/runs/3301257470), [2](https://github.com/mihaimaruseac/root-signing/actions/runs/3275484644)).

According to https://github.com/orgs/community/discussions/26684, inserting this `if` statement should prevent the job from running. Did not insert it in actions that are following the main one since if the first one does not run none of the others would (if I read the guide properly). Also, did not add the `if` statement to the other workflow files since those are not run on cron and should actually run on PRs or workflow dispatch. Only cron jobs are the ones that need to be disabled.

Closes #515

Signed-off-by: Mihai Maruseac <mihai.maruseac@gmail.com>


#### Summary
I got a fork of this repository that I sync to head when there is a new round of TUF root signing and it seems now we have actions that are running on cron and asking for credentials. Since the fork does not have them, the action fails. This results in notifications being sent to the fork owner.

#### Release Note

NONE

#### Documentation

NONE