### PR TITLE
ci: add auto-submit workflow for snapshot/timestamp

### DIFF
--- a/.github/workflows/review-snapshot-timestamp.yml
+++ b/.github/workflows/review-snapshot-timestamp.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Stable Snapshot and Timestamp
+name: Review Snapshot and Timestamp
 
 permissions: read-all
 
@@ -21,7 +21,7 @@ permissions: read-all
 # when new published metadata is submitted.
 on:
   # Enable cron for checking if a snapshot/timestamp PR needs review
-  # every 
+  # every 6 hours and attempts to merge.
   schedule:
     - cron: '0 */6 * * *' # every 6 hours
   workflow_dispatch:

--- a/.github/workflows/review-snapshot-timestamp.yml
+++ b/.github/workflows/review-snapshot-timestamp.yml
@@ -1,0 +1,41 @@
+#
+# Copyright 2022 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Stable Snapshot and Timestamp
+
+permissions: read-all
+
+# Execute this as a biweekly cron job and on changes to repository/
+# when new published metadata is submitted.
+on:
+  # Enable cron for checking if a snapshot/timestamp PR needs review
+  # every 
+  schedule:
+    - cron: '0 */6 * * *' # every 6 hours
+  workflow_dispatch:
+
+jobs:
+  review:
+    runs-on: ubuntu-20.04
+    permissions:
+      pull-requests: 'write'
+      contents: 'write'
+    env:
+      GITHUB_TOKEN: ${{ secrets.SIGSTORE_ROOT_SIGNING_FINE_GRAINED_PAT }}
+    steps:
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+      - run: |
+          set -euo pipefail
+          ./.github/workflows/scripts/report-failure.sh

--- a/.github/workflows/scripts/review-pull-request.sh
+++ b/.github/workflows/scripts/review-pull-request.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#
+# Copyright 2022 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+# Gets the open snapshot/timestamp update pull requests of the repository
+timestamp_update() {
+    gh api -H "Accept: application/vnd.github.v3+json" "/repos/$GITHUB_REPOSITORY/pulls?head=sigstore:update-snapshot-timestamp" | jq '.[0]' | jq 'select (.!=null)'
+}
+
+UPDATE_PR=$(timestamp_update)
+if [[ -z "$UPDATE_PR" ]]; then
+    PULL_NUMBER=$(echo $UPDATE_PR | jq -r '.number')
+
+    # Approve PR
+    curl \
+    -o review_output.json
+    -X POST \
+    -H "Accept: application/vnd.github+json" \
+    -H "Authorization: Bearer $GITHUB_TOKEN" \
+    https://api.github.com/repos/$GITHUB_REPOSITORY/pulls/$PULL_NUMBER/reviews
+
+    REVIEW_ID=$(cat review_output.json | jq -r '.id')
+    GH_TOKEN=$GITHUB_TOKEN gh api \
+    --method POST \
+    -H "Accept: application/vnd.github+json" \
+    /repos/$GITHUB_REPOSITORY/pulls/$PULL_NUMBER/reviews/$REVIEW_ID/events \
+    -f event='APPROVE'
+
+    # Attempt to merge PR
+    GH_TOKEN=$GITHUB_TOKEN gh api \
+    --method PUT \
+    -H "Accept: application/vnd.github+json" \
+    /repos/$GITHUB_REPOSITORY/pulls/$PULL_NUMBER/merge \
+    -f commit_title='Update Snapshot and Timestamp' \
+    -f commit_message='update snapshot and timestamp' 
+fi

--- a/.github/workflows/scripts/review-pull-request.sh
+++ b/.github/workflows/scripts/review-pull-request.sh
@@ -18,33 +18,33 @@ set -euo pipefail
 
 # Gets the open snapshot/timestamp update pull requests of the repository
 timestamp_update() {
-    gh api -H "Accept: application/vnd.github.v3+json" "/repos/$GITHUB_REPOSITORY/pulls?head=sigstore:update-snapshot-timestamp" | jq '.[0]' | jq 'select (.!=null)'
+    gh api -H "Accept: application/vnd.github.v3+json" "/repos/${GITHUB_REPOSITORY}/pulls?head=sigstore:update-snapshot-timestamp" | jq '.[0]' | jq 'select (.!=null)'
 }
 
 UPDATE_PR=$(timestamp_update)
-if [[ -z "$UPDATE_PR" ]]; then
-    PULL_NUMBER=$(echo $UPDATE_PR | jq -r '.number')
+if [[ -z "${UPDATE_PR}" ]]; then
+    PULL_NUMBER=$(echo "${UPDATE_PR}" | jq -r '.number')
 
     # Approve PR
     curl \
-    -o review_output.json
+    -o review_output.json \
     -X POST \
     -H "Accept: application/vnd.github+json" \
-    -H "Authorization: Bearer $GITHUB_TOKEN" \
-    https://api.github.com/repos/$GITHUB_REPOSITORY/pulls/$PULL_NUMBER/reviews
+    -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+    https://api.github.com/repos/"${GITHUB_REPOSITORY}"/pulls/"${PULL_NUMBER}"/reviews
 
-    REVIEW_ID=$(cat review_output.json | jq -r '.id')
+    REVIEW_ID=$(jq -r '.id' review_output.json)
     GH_TOKEN=$GITHUB_TOKEN gh api \
     --method POST \
     -H "Accept: application/vnd.github+json" \
-    /repos/$GITHUB_REPOSITORY/pulls/$PULL_NUMBER/reviews/$REVIEW_ID/events \
+    /repos/"${GITHUB_REPOSITORY}"/pulls/"${PULL_NUMBER}"/reviews/"${REVIEW_ID}"/events \
     -f event='APPROVE'
 
     # Attempt to merge PR
-    GH_TOKEN=$GITHUB_TOKEN gh api \
+    GH_TOKEN="${GITHUB_TOKEN}" gh api \
     --method PUT \
     -H "Accept: application/vnd.github+json" \
-    /repos/$GITHUB_REPOSITORY/pulls/$PULL_NUMBER/merge \
+    /repos/"${GITHUB_REPOSITORY}"/pulls/"${PULL_NUMBER}"/merge \
     -f commit_title='Update Snapshot and Timestamp' \
     -f commit_message='update snapshot and timestamp' 
 fi


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

This PR adds an auto-submit bot for the snapshot/timestamp updates. The workflow will still trigger, and then this will run every 6 hours to (1) Check for any outstanding snapshot/timestamp updates (2) Start a review and approve and (3) Attempt to merge.

Fixes https://github.com/sigstore/root-signing/issues/553

cc @haydentherapper 

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->