### PR TITLE
update to use go1.19 and bump golangci-lint

### DIFF
--- a/.github/workflows/cosign-test.yml
+++ b/.github/workflows/cosign-test.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b # v2.8.0
 
       # Set up a repository server with python
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@2c3dd9e7e29afd70cc0950079bde6c979d1f69f9 # v4.3.1
         with:
           python-version: '3.x'
       - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0

--- a/.github/workflows/reuseable-snapshot-timestamp.yml
+++ b/.github/workflows/reuseable-snapshot-timestamp.yml
@@ -77,7 +77,8 @@ jobs:
           echo "LOCAL=1" >> $GITHUB_ENV
       - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
-          go-version: 1.18.x
+          go-version: 1.19
+          check-latest: true
       - uses: google-github-actions/setup-gcloud@d51b5346f85640ec2aa2fa057354d2b82c2fcbce # v1.0.1
         with:
           project_id: sigstore-root-signing

--- a/.github/workflows/staging-initialize.yml
+++ b/.github/workflows/staging-initialize.yml
@@ -56,7 +56,8 @@ jobs:
           echo "LOCAL=1" >> $GITHUB_ENV
       - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
-          go-version: 1.18.x
+          go-version: 1.19
+          check-latest: true
       - uses: google-github-actions/setup-gcloud@d51b5346f85640ec2aa2fa057354d2b82c2fcbce # v1.0.1
         with:
           project_id: sigstore-root-signing

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -36,7 +36,8 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
-          go-version: 1.18.x
+          go-version: 1.19
+          check-latest: true
       - uses: google-github-actions/setup-gcloud@d51b5346f85640ec2aa2fa057354d2b82c2fcbce # v1.0.1
         with:
           project_id: project-rekor

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ on:
       - 'ceremony/**'
 
 env:
-  GO_VERSION: 1.18
+  GO_VERSION: 1.19
 
 jobs:
   golangci:
@@ -42,7 +42,7 @@ jobs:
         uses: golangci/golangci-lint-action@0ad9a0988b3973e851ab0a07adf248ec2e100376 # v3
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.48
+          version: v1.50.1
           args: --timeout=5m
 
   yamllint:

--- a/.github/workflows/tuf_client_tests.yml
+++ b/.github/workflows/tuf_client_tests.yml
@@ -42,7 +42,8 @@ jobs:
       # Test with go-tuf client
       - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
-          go-version: '1.18.x'
+          go-version: 1.19
+          check-latest: true
       - run: |
           go install github.com/theupdateframework/go-tuf/cmd/tuf-client@v0.5.1
       - run: |

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -37,7 +37,8 @@ jobs:
           echo "GCS_PREPROD_REPO=https://storage.googleapis.com/sigstore-preprod-tuf-root" >> $GITHUB_ENV
       - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
-          go-version: '1.18.x'
+          go-version: 1.19
+          check-latest: true
       - name: install deps
         run: |
           sudo apt-get install libpcsclite-dev

--- a/cmd/verify/app/repository.go
+++ b/cmd/verify/app/repository.go
@@ -101,7 +101,7 @@ func (r fileRemoteStore) GetTarget(target string) (io.ReadCloser, int64, error) 
 }
 
 // Metadata helpers
-type signedMeta struct {
+type SignedMeta struct {
 	Type    string    `json:"_type"`
 	Expires time.Time `json:"expires"`
 	Version int       `json:"version"`
@@ -120,8 +120,8 @@ func isMetaFile(e os.DirEntry) (bool, error) {
 	return info.Mode().IsRegular(), nil
 }
 
-func PrintAndGetSignedMeta(role string, signed json.RawMessage) (*signedMeta, error) {
-	sm := &signedMeta{}
+func PrintAndGetSignedMeta(role string, signed json.RawMessage) (*SignedMeta, error) {
+	sm := &SignedMeta{}
 	if err := json.Unmarshal(signed, sm); err != nil {
 		return nil, err
 	}
@@ -247,9 +247,9 @@ func verifySignatures(db *verify.DB, s *data.Signed, role string) (int, error) {
 	return dbRole.Threshold, nil
 }
 
-func getClientState(local client.LocalStore) (map[string]signedMeta, error) {
+func getClientState(local client.LocalStore) (map[string]SignedMeta, error) {
 	trustedMeta, err := local.GetMeta()
-	res := make(map[string]signedMeta, len(trustedMeta))
+	res := make(map[string]SignedMeta, len(trustedMeta))
 	if err != nil {
 		return nil, errors.Wrap(err, "getting trusted meta")
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sigstore/root-signing
 
-go 1.18
+go 1.19
 
 require (
 	github.com/go-piv/piv-go v1.10.0


### PR DESCRIPTION
#### Summary
- update to use go1.19 and bump golangci-lint