### PR TITLE
fix: update gitattributes to ignore autocrlf

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# These directories contain TUF and other assets that are either digested
+# or sized-checked so CRLF normalization breaks them.
+ceremony/** binary
+repository/** binary


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Applies to both the `ceremony/` and `repository/` directories. 

Thanks @woodruffw !

Fixes https://github.com/sigstore/root-signing/issues/587