### PR TITLE
Update github workflow links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ The current published repository metadata lives in the [repository](/repository/
 | [ctfe_2022.pub](repository/repository/targets/ctfe_2022.pub)        |  Certificate Transparency log key for the 2022 log shard (`ctfe.sigstore.dev/2022`), that is used for certificates issued by Fulcio and used to verify signed certificate timestamps (SCTs) for inclusion into the log. | 
 | [artifact.pub](repository/repository/targets/artifact.pub) | Key that signs Sigstore project (Cosign, Rekor, Fulcio) releases. |
 
-* [snapshot.json]((repository/repository/snapshot.json)): The snapshot ensures consistency of the metadata files. It has a lifetime of 2 weeks and is re-signed by a [GitHub workflow](https://github.com/sigstore/root-signing/blob/main/.github/workflows/snapshot-timestamp.yml).
-* [timestamp.json]((repository/repository/timestamp.json)): The timestamp indicates the freshness of the metadata files. It has a lifetime of 2 weeks and is re-signed by a [GitHub workflow](https://github.com/sigstore/root-signing/blob/main/.github/workflows/snapshot-timestamp.yml).
+* [snapshot.json](repository/repository/snapshot.json): The snapshot ensures consistency of the metadata files. It has a lifetime of 2 weeks and is re-signed by a [GitHub workflow](https://github.com/sigstore/root-signing/blob/main/.github/workflows/stable-snapshot-timestamp.yml).
+* [timestamp.json](repository/repository/timestamp.json): The timestamp indicates the freshness of the metadata files. It has a lifetime of 2 weeks and is re-signed by a [GitHub workflow](https://github.com/sigstore/root-signing/blob/main/.github/workflows/stable-snapshot-timestamp.yml).
 
 
 ### Root locations


### PR DESCRIPTION


Signed-off-by: Daniel Bevenius <daniel.bevenius@gmail.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
This commit updates the links to the snapshot and timestamp workflow files which are currently producing 404 Not Found.

It looks this file was renamed in Commit 17d52ecf88be6066b68eb11b43c31f13936c359a ("ci: add reusable workflow for configuring snapshot and timestamp (#450)").

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
NONE

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
NONE