### PR TITLE
Make sure tuf sign works with the "test HSM key"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,3 +39,11 @@ yamllint: ## Runs the yamllint linter.
 			extraargs="-f github"; \
 		fi; \
 		yamllint -c .yamllint.yaml . $$extraargs
+
+.PHONY: keygen
+keygen:
+	@go build -tags=pivkey -o $@ ./tests/keygen
+
+.PHONY: tuf
+tuf:
+	@go build -tags=pivkey -o $@ ./cmd/tuf

--- a/cmd/tuf/app/sign.go
+++ b/cmd/tuf/app/sign.go
@@ -56,7 +56,7 @@ func Sign() *ffcli.Command {
 		roles      = roleFlag{}
 		repository = flagset.String("repository", "", "path to the staged repository")
 		sk         = flagset.Bool("sk", false, "indicates use of a hardware key for signing")
-		key        = flagset.String("key", "", "reference to an signer for signing")
+		key        = flagset.String("key", "", "reference to a signer for signing")
 		// TODO(https://github.com/sigstore/root-signing/issues/381):
 		// This can be removed after v5 root-signing is complete.
 		addDeprecatedKeyFormat = flagset.Bool("add-deprecated", false, "adds the deprecated ecdsa key format to associate signatures")

--- a/cmd/tuf/app/sign.go
+++ b/cmd/tuf/app/sign.go
@@ -21,6 +21,7 @@ package app
 import (
 	"bytes"
 	"context"
+	"crypto"
 	"flag"
 	"fmt"
 	"strings"
@@ -55,7 +56,7 @@ func Sign() *ffcli.Command {
 		roles      = roleFlag{}
 		repository = flagset.String("repository", "", "path to the staged repository")
 		sk         = flagset.Bool("sk", false, "indicates use of a hardware key for signing")
-		key        = flagset.String("key", "", "reference to an onine signer for signing")
+		key        = flagset.String("key", "", "reference to an online signer for signing")
 		// TODO(https://github.com/sigstore/root-signing/issues/381):
 		// This can be removed after v5 root-signing is complete.
 		addDeprecatedKeyFormat = flagset.Bool("add-deprecated", false, "adds the deprecated ecdsa key format to associate signatures")
@@ -68,9 +69,9 @@ func Sign() *ffcli.Command {
 		ShortHelp:  "tuf signs the top-level metadata for role in the given repository",
 		LongHelp: `tuf signs the top-level metadata for role in the given repository.
 		Signing a lower level, e.g. snapshot or timestamp, before signing the root and target
-		will trigger a warning. 
+		will trigger a warning.
 		One of sk or a key reference must be provided.
-		
+
 	EXAMPLES
 	# sign staged repository at ceremony/YYYY-MM-DD
 	tuf sign -role root -repository ceremony/YYYY-MM-DD`,
@@ -136,7 +137,15 @@ func getSigner(ctx context.Context, sk bool, keyRef string) (signature.Signer, e
 		return pivKey.SignerVerifier()
 	}
 	// A key reference was provided.
-	return csignature.SignerVerifierFromKeyRef(ctx, keyRef, nil)
+	signer, err := signature.LoadSignerFromPEMFile(keyRef, crypto.SHA256, nil)
+	if err != nil {
+		signer, err = csignature.SignerVerifierFromKeyRef(ctx, keyRef, nil)
+		if err != nil {
+			return nil, err
+		}
+
+	}
+	return signer, nil
 }
 
 func SignCmd(ctx context.Context, directory string, roles []string, signer signature.Signer,

--- a/tests/keygen/app/gen-root.go
+++ b/tests/keygen/app/gen-root.go
@@ -73,6 +73,5 @@ var genRootCmd = &cobra.Command{
 func init() {
 	genRootCmd.Flags().StringVar(&outputCA, "output-ca", "test-root-attestation.ca", "path to file to write output root CA")
 	genRootCmd.Flags().StringVar(&outputSigner, "output-signer", "test-root.pem", "path to file to write output root CA signer")
-
 	rootCmd.AddCommand(genRootCmd)
 }


### PR DESCRIPTION
Signed-off-by: Fredrik Skogman <kommendorkapten@github.com>

#### Summary
When generating local HSM for testing, they can not be used to sign `root.json` nor `target.json`. This PR fixes this. The e2e worked as they are using a different code path, which is now added into `tuf sign`.

#### Release Note
N/A

#### Documentation
N/A