### PR TITLE
Add delegation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ piv-attestation-ca.pem
 /keygen
 test-root.pem
 test-root-attestation.ca
+*~

--- a/Makefile
+++ b/Makefile
@@ -47,3 +47,7 @@ keygen:
 .PHONY: tuf
 tuf:
 	@go build -tags=pivkey -o $@ ./cmd/tuf
+
+.PHONY: test
+test:
+	@go test -tags=pivkey ./...

--- a/cmd/tuf/app/add-delegation.go
+++ b/cmd/tuf/app/add-delegation.go
@@ -47,13 +47,11 @@ func (f *keysFlag) Set(value string) error {
 
 func AddDelegation() *ffcli.Command {
 	var (
-		flagset     = flag.NewFlagSet("tuf add-delegation", flag.ExitOnError)
-		repository  = flagset.String("repository", "", "path to the staged repository")
-		name        = flagset.String("name", "", "name of the delegatee")
-		keys        = keysFlag{}
-		path        = flagset.String("path", "", "path for the delegation. The name must be a prefix of the path.")
-		terminating = flagset.Bool("terminating", false, "indicated whether the delegation is terminating")
-		targets     = flagset.String("target-meta", "", "path to a target configuration file")
+		flagset    = flag.NewFlagSet("tuf add-delegation", flag.ExitOnError)
+		repository = flagset.String("repository", "", "path to the staged repository")
+		name       = flagset.String("name", "", "name of the delegatee")
+		keys       = keysFlag{}
+		targets    = flagset.String("target-meta", "", "path to a target configuration file")
 	)
 	flagset.Var(&keys, "public-key", "public key reference for the delegatee")
 	return &ffcli.Command{
@@ -66,7 +64,7 @@ but will default to the name if unspecified.
 
 	EXAMPLES
 	# add-delegation repository at ceremony/YYYY-MM-DD
-	tuf add-delegation -repository ceremony/YYYY-MM-DD -name $NAME -key $KEY_A -key $KEY_B -path $PATH`,
+	tuf add-delegation -repository ceremony/YYYY-MM-DD -name $NAME -key $KEY_A -key $KEY_B`,
 		FlagSet: flagset,
 		Exec: func(ctx context.Context, args []string) error {
 			if *repository == "" {
@@ -78,12 +76,9 @@ but will default to the name if unspecified.
 			if len(keys) == 0 {
 				return flag.ErrHelp
 			}
-			if !strings.HasPrefix(*path, *name) {
-				// The path must be contained to start with
-				// name of the delegation
-				return flag.ErrHelp
-			}
-			return DelegationCmd(ctx, *repository, *name, *path, *terminating, keys, *targets)
+			path := filepath.Join(*name, "*")
+			terminating := true
+			return DelegationCmd(ctx, *repository, *name, path, terminating, keys, *targets)
 		},
 	}
 }

--- a/cmd/tuf/app/add-delegation.go
+++ b/cmd/tuf/app/add-delegation.go
@@ -185,9 +185,11 @@ func DelegationCmd(ctx context.Context, opts *DelegationOptions) error {
 			base := filepath.Base(tt)
 			dir := filepath.Dir(tt)
 			toDir := filepath.Join(opts.Directory, "staged", "targets", dir)
-			os.MkdirAll(toDir, 0750)
+			err = os.MkdirAll(toDir, 0750)
+			if err != nil {
+				return err
+			}
 			to, err := os.Create(filepath.Join(toDir, base))
-
 			if err != nil {
 				return err
 			}

--- a/cmd/tuf/app/add-delegation.go
+++ b/cmd/tuf/app/add-delegation.go
@@ -176,7 +176,15 @@ func DelegationCmd(ctx context.Context, opts *DelegationOptions) error {
 			return err
 		}
 
-		for tt, custom := range meta {
+		// Remove the targets as requested
+		for tt := range meta.Del {
+			err = repo.RemoveTarget(tt)
+			if err != nil {
+				return err
+			}
+		}
+
+		for tt, custom := range meta.Add {
 			from, err := os.Open(tt)
 			if err != nil {
 				return err

--- a/cmd/tuf/app/add-delegation.go
+++ b/cmd/tuf/app/add-delegation.go
@@ -183,7 +183,11 @@ func DelegationCmd(ctx context.Context, opts *DelegationOptions) error {
 			}
 			defer from.Close()
 			base := filepath.Base(tt)
-			to, err := os.Create(filepath.Join(opts.Directory, "staged", "targets", base))
+			dir := filepath.Dir(tt)
+			toDir := filepath.Join(opts.Directory, "staged", "targets", dir)
+			os.MkdirAll(toDir, 0750)
+			to, err := os.Create(filepath.Join(toDir, base))
+
 			if err != nil {
 				return err
 			}
@@ -192,7 +196,7 @@ func DelegationCmd(ctx context.Context, opts *DelegationOptions) error {
 				return err
 			}
 			fmt.Fprintln(os.Stderr, "Created target file at ", to.Name())
-			if err := repo.AddTargetsWithExpiresToPreferredRole([]string{base}, custom, GetExpiration("targets"), opts.Name); err != nil {
+			if err := repo.AddTargetsWithExpiresToPreferredRole([]string{tt}, custom, GetExpiration("targets"), opts.Name); err != nil {
 				return fmt.Errorf("error adding targets %w", err)
 			}
 		}

--- a/cmd/tuf/app/add-delegation.go
+++ b/cmd/tuf/app/add-delegation.go
@@ -17,7 +17,6 @@ package app
 
 import (
 	"context"
-	"crypto"
 	"errors"
 	"flag"
 	"fmt"
@@ -28,7 +27,6 @@ import (
 
 	pkeys "github.com/sigstore/root-signing/pkg/keys"
 	prepo "github.com/sigstore/root-signing/pkg/repo"
-	"github.com/sigstore/sigstore/pkg/signature"
 	"github.com/theupdateframework/go-tuf/data"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
@@ -131,7 +129,7 @@ func DelegationCmd(ctx context.Context, opts *DelegationOptions) error {
 	keys := []*data.PublicKey{}
 	ids := []string{}
 	for _, keyRef := range opts.KeyRefs {
-		verifier, err := getVerifier(ctx, keyRef)
+		verifier, err := GetVerifier(ctx, keyRef)
 		if err != nil {
 			return err
 		}
@@ -222,10 +220,4 @@ func DelegationCmd(ctx context.Context, opts *DelegationOptions) error {
 		return err
 	}
 	return prepo.SetSignedMeta(store, "targets.json", &data.Signed{Signatures: sigs, Signed: signed})
-}
-
-func getVerifier(ctx context.Context, keyRef string) (signature.Verifier, error) {
-	verifier, err := signature.LoadVerifierFromPEMFile(keyRef, crypto.SHA256)
-
-	return verifier, err
 }

--- a/cmd/tuf/app/common.go
+++ b/cmd/tuf/app/common.go
@@ -1,0 +1,68 @@
+//
+// Copyright 2023 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package app
+
+import (
+	"context"
+	"crypto"
+	"fmt"
+
+	"github.com/sigstore/cosign/pkg/cosign/pivkey"
+	csignature "github.com/sigstore/cosign/pkg/signature"
+	"github.com/sigstore/sigstore/pkg/signature"
+)
+
+func GetSigner(ctx context.Context, sk bool, keyRef string) (signature.Signer, error) {
+	if sk {
+		//nolint: staticcheck
+		pivKey, err := pivkey.GetKeyWithSlot("signature")
+		//nolint: staticcheck
+		if err != nil {
+			return nil, err
+		}
+		return pivKey.SignerVerifier()
+	}
+	// A key reference was provided.
+	// First try to load it as a regular PEM encoded private key.
+	signer, err := signature.LoadSignerFromPEMFile(keyRef, crypto.SHA256, nil)
+	if err != nil {
+		var innerError error
+		signer, innerError = csignature.SignerVerifierFromKeyRef(ctx, keyRef, nil)
+		if innerError != nil {
+			// Only print this message if both attempts failed.
+			// As there is a natual fallthrough here, always
+			// logging the first error could be noisy.
+			fmt.Printf("failed to load key as PEM encoded: %s, trying other methods: ", err)
+			return nil, innerError
+		}
+
+	}
+	return signer, nil
+}
+
+func GetVerifier(ctx context.Context, keyRef string) (signature.Verifier, error) {
+	verifier, err := signature.LoadVerifierFromPEMFile(keyRef, crypto.SHA256)
+
+	return verifier, err
+}
+
+// The DSSE Pre-Authentication Encoding
+// https://github.com/secure-systems-lab/dsse/blob/master/protocol.md#signature-definition
+func PAE(challenge, nonce string) []byte {
+	return []byte(fmt.Sprintf("key-kop-v1 %d %s %d %s",
+		len(challenge), challenge,
+		len(nonce), nonce))
+}

--- a/cmd/tuf/app/init.go
+++ b/cmd/tuf/app/init.go
@@ -17,7 +17,6 @@ package app
 
 import (
 	"context"
-	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
@@ -80,11 +79,11 @@ func Init() *ffcli.Command {
 		Name:       "init",
 		ShortUsage: "tuf init initializes a new TUF repository",
 		ShortHelp:  "tuf init initializes a new TUF repository",
-		LongHelp: `tuf init initializes a new TUF repository to the 
-		specified repository directory. It will create unpopulated directories 
+		LongHelp: `tuf init initializes a new TUF repository to the
+		specified repository directory. It will create unpopulated directories
 		keys/, staged/, and staged/targets under the repository with threshold 3
 		and a 4 month expiration.
-		
+
 	EXAMPLES
 	# initialize repository at ceremony/YYYY-MM-DD
 	tuf init -repository ceremony/YYYY-MM-DD`,
@@ -137,7 +136,7 @@ func Init() *ffcli.Command {
 // Revoked keys will be automatically calculated given the previous root and the signers in directory.
 // Signature placeholders for each key will be added to the root.json and targets.json file.
 func InitCmd(ctx context.Context, directory, previous string,
-	threshold int, targetsConfig map[string]json.RawMessage,
+	threshold int, targetsConfig *prepo.TargetMetaConfig,
 	targetsDir string,
 	snapshotRef string, timestampRef string,
 	deprecatedKeyFormat bool) error {
@@ -204,7 +203,7 @@ func InitCmd(ctx context.Context, directory, previous string,
 	// Add targets (copy them into the repository and add them to the targets.json)
 	// Add the new targets in the config.
 	expectedTargets := make(map[string]bool)
-	for tt, custom := range targetsConfig {
+	for tt, custom := range targetsConfig.Add {
 		from, err := os.Open(filepath.Join(targetsDir, tt))
 		if err != nil {
 			return err

--- a/cmd/tuf/app/key-pop-sign.go
+++ b/cmd/tuf/app/key-pop-sign.go
@@ -1,0 +1,94 @@
+//
+// Copyright 2023 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package app
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"flag"
+	"fmt"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+	"github.com/sigstore/sigstore/pkg/signature"
+	"github.com/sigstore/sigstore/pkg/signature/options"
+)
+
+func KeyPOPSign() *ffcli.Command {
+	var (
+		flagset   = flag.NewFlagSet("tuf key-pop-sign", flag.ExitOnError)
+		challenge = flagset.String("challenge", "", "the challenge to sign, for a delegate this is the delegate name")
+		nonce     = flagset.String("nonce", "", "the nonce delivered out of band to the key holder")
+		key       = flagset.String("key", "", "reference to a signer for signing")
+		sk        = flagset.Bool("sk", false, "indicates use of a hardware key for signing")
+	)
+
+	return &ffcli.Command{
+		Name:       "key-pop-sign",
+		ShortUsage: "tuf key-pop-sign -challenge value -nonce nonce -key ref",
+		ShortHelp:  "Sign a proof of possession of a key",
+		LongHelp:   "Sign a proof of possession of a key. The base64 encoded signature is printed to stdout",
+		FlagSet:    flagset,
+		Exec: func(ctx context.Context, args []string) error {
+			if *challenge == "" {
+				return flag.ErrHelp
+			}
+			if *nonce == "" {
+				return flag.ErrHelp
+			}
+			if !*sk && *key == "" {
+				return flag.ErrHelp
+			}
+
+			signer, err := getSigner(ctx, *sk, *key)
+			if err != nil {
+				return err
+			}
+
+			return KeyPOPSignCmd(ctx, *challenge, *nonce, signer)
+		},
+	}
+}
+
+// The DSSE Pre-Authentication Encoding
+// https://github.com/secure-systems-lab/dsse/blob/master/protocol.md#signature-definition
+func PAE(challenge, nonce string) []byte {
+	return []byte(fmt.Sprintf("key-kop-v1 %d %s %d %s",
+		len(challenge), challenge,
+		len(nonce), nonce))
+}
+
+func KeyPOPSignCmd(ctx context.Context,
+	challenge, nonce string,
+	signer signature.Signer) error {
+	sig, err := DoKeyPOPSign(ctx, challenge, nonce, signer)
+
+	if err != nil {
+		return err
+	}
+	fmt.Println(base64.StdEncoding.EncodeToString(sig))
+
+	return nil
+}
+
+func DoKeyPOPSign(ctx context.Context,
+	challenge, nonce string,
+	signer signature.Signer) ([]byte, error) {
+	data := PAE(challenge, nonce)
+	return signer.SignMessage(bytes.NewReader(data),
+		options.WithContext(ctx))
+
+}

--- a/cmd/tuf/app/key-pop-sign.go
+++ b/cmd/tuf/app/key-pop-sign.go
@@ -53,7 +53,7 @@ func KeyPOPSign() *ffcli.Command {
 				return flag.ErrHelp
 			}
 
-			signer, err := getSigner(ctx, *sk, *key)
+			signer, err := GetSigner(ctx, *sk, *key)
 			if err != nil {
 				return err
 			}
@@ -61,14 +61,6 @@ func KeyPOPSign() *ffcli.Command {
 			return KeyPOPSignCmd(ctx, *challenge, *nonce, signer)
 		},
 	}
-}
-
-// The DSSE Pre-Authentication Encoding
-// https://github.com/secure-systems-lab/dsse/blob/master/protocol.md#signature-definition
-func PAE(challenge, nonce string) []byte {
-	return []byte(fmt.Sprintf("key-kop-v1 %d %s %d %s",
-		len(challenge), challenge,
-		len(nonce), nonce))
 }
 
 func KeyPOPSignCmd(ctx context.Context,

--- a/cmd/tuf/app/key-pop-verify.go
+++ b/cmd/tuf/app/key-pop-verify.go
@@ -56,7 +56,7 @@ func KeyPOPVerify() *ffcli.Command {
 				return flag.ErrHelp
 			}
 
-			verifier, err := getVerifier(ctx, *key)
+			verifier, err := GetVerifier(ctx, *key)
 			if err != nil {
 				return err
 			}

--- a/cmd/tuf/app/key-pop-verify.go
+++ b/cmd/tuf/app/key-pop-verify.go
@@ -1,0 +1,89 @@
+//
+// Copyright 2023 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package app
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"flag"
+	"fmt"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+	"github.com/sigstore/sigstore/pkg/signature"
+	"github.com/sigstore/sigstore/pkg/signature/options"
+)
+
+func KeyPOPVerify() *ffcli.Command {
+	var (
+		flagset   = flag.NewFlagSet("tuf key-pop-sign", flag.ExitOnError)
+		challenge = flagset.String("challenge", "", "the challenge to sign, for a delegate this is the delegate name")
+		nonce     = flagset.String("nonce", "", "the nonce delivered out of band to the key holder")
+		key       = flagset.String("key", "", "reference to a signer for signing")
+		sig       = flagset.String("sig", "", "base64 encoded signature to verify")
+	)
+
+	return &ffcli.Command{
+		Name:       "key-pop-verify",
+		ShortUsage: "tuf key-pop-verify -challenge value -nonce nonce -key ref -sig base64e",
+		ShortHelp:  "Verify a proof of possession of a key",
+		LongHelp:   "Verify a proof of possession of a key",
+		FlagSet:    flagset,
+		Exec: func(ctx context.Context, args []string) error {
+			if *challenge == "" {
+				return flag.ErrHelp
+			}
+			if *nonce == "" {
+				return flag.ErrHelp
+			}
+			if *key == "" {
+				return flag.ErrHelp
+			}
+			if *sig == "" {
+				return flag.ErrHelp
+			}
+
+			verifier, err := getVerifier(ctx, *key)
+			if err != nil {
+				return err
+			}
+			sigBytes, err := base64.StdEncoding.DecodeString(*sig)
+			if err != nil {
+				return err
+			}
+
+			return KeyPOPVerifyCmd(ctx, *challenge, *nonce, verifier, sigBytes)
+		},
+	}
+}
+
+func KeyPOPVerifyCmd(ctx context.Context,
+	challenge, nonce string,
+	verifier signature.Verifier,
+	sig []byte) error {
+	data := PAE(challenge, nonce)
+
+	err := verifier.VerifySignature(bytes.NewReader(sig),
+		bytes.NewReader(data),
+		options.WithContext(ctx))
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("Signature verified ok")
+
+	return nil
+}

--- a/cmd/tuf/app/sign.go
+++ b/cmd/tuf/app/sign.go
@@ -31,7 +31,6 @@ import (
 	csignature "github.com/sigstore/cosign/pkg/signature"
 	"github.com/sigstore/root-signing/pkg/keys"
 	"github.com/sigstore/root-signing/pkg/repo"
-	prepo "github.com/sigstore/root-signing/pkg/repo"
 	"github.com/sigstore/sigstore/pkg/signature"
 	"github.com/sigstore/sigstore/pkg/signature/options"
 	cjson "github.com/tent/canonical-json-go"
@@ -146,7 +145,7 @@ func getSigner(ctx context.Context, sk bool, keyRef string) (signature.Signer, e
 			// Only print this message if both attempts failed.
 			// As there is a natual fallthrough here, always
 			// logging the first error could be noisy.
-			fmt.Printf("failed to load key as PEM encoded: %s, trying other methods", err)
+			fmt.Printf("failed to load key as PEM encoded: %s, trying other methods: ", err)
 			return nil, innerError
 		}
 
@@ -164,7 +163,7 @@ func SignCmd(ctx context.Context, directory string, roles []string, signer signa
 
 	for _, name := range roles {
 		if bumpVersion {
-			if err := prepo.BumpMetadataVersion(store, name); err != nil {
+			if err := repo.BumpMetadataVersion(store, name); err != nil {
 				return err
 			}
 		}
@@ -284,7 +283,7 @@ func SignMeta(ctx context.Context, store tuf.LocalStore, name string, signer sig
 			strings.Join(keyIDs, ", "), name, roleSigningKeys)
 	}
 
-	return prepo.SetSignedMeta(store, name, &data.Signed{Signatures: sigs, Signed: s.Signed})
+	return repo.SetSignedMeta(store, name, &data.Signed{Signatures: sigs, Signed: s.Signed})
 }
 
 // Pre-entries are defined when there are Signatures in the Signed metadata

--- a/cmd/tuf/main.go
+++ b/cmd/tuf/main.go
@@ -36,7 +36,17 @@ func main() {
 	root := &ffcli.Command{
 		ShortUsage:  "tuf [flags] <subcommand>",
 		FlagSet:     rootFlagSet,
-		Subcommands: []*ffcli.Command{app.Init(), app.AddKey(), app.Snapshot(), app.AddDelegation(), app.Timestamp(), app.Sign(), app.Publish()},
+		Subcommands: []*ffcli.Command{
+			app.Init(),
+			app.AddKey(),
+			app.Snapshot(),
+			app.AddDelegation(),
+			app.Timestamp(),
+			app.Sign(),
+			app.Publish(),
+			app.KeyPOPSign(),
+			app.KeyPOPVerify(),
+		},
 		Exec: func(context.Context, []string) error {
 			return flag.ErrHelp
 		},

--- a/config/targets-metadata.yml
+++ b/config/targets-metadata.yml
@@ -1,35 +1,36 @@
 # The top-level targets paths.
-fulcio_v1.crt.pem:
-  sigstore:
-    uri: https://fulcio.sigstore.dev
-    usage: Fulcio
-    status: Active
-fulcio_intermediate_v1.crt.pem:
-  sigstore:
-    uri: https://fulcio.sigstore.dev
-    usage: Fulcio
-    status: Active
-fulcio.crt.pem:
-  sigstore:
-    uri: https://fulcio.sigstore.dev
-    usage: Fulcio
-    status: Expired
-ctfe.pub:
-  sigstore:
-    uri: https://ctfe.sigstore.dev/test
-    usage: CTFE
-    status: Active
-ctfe_2022.pub:
-  sigstore:
-    uri: https://ctfe.sigstore.dev/2022
-    usage: CTFE
-    status: Active
-rekor.pub:
-  sigstore:
-    uri: https://rekor.sigstore.dev
-    usage: Rekor
-    status: Active
-artifact.pub:
-  sigstore:
-    usage: Unknown
-    status: Active
+add:
+  fulcio_v1.crt.pem:
+    sigstore:
+      uri: https://fulcio.sigstore.dev
+      usage: Fulcio
+      status: Active
+  fulcio_intermediate_v1.crt.pem:
+    sigstore:
+      uri: https://fulcio.sigstore.dev
+      usage: Fulcio
+      status: Active
+  fulcio.crt.pem:
+    sigstore:
+      uri: https://fulcio.sigstore.dev
+      usage: Fulcio
+      status: Expired
+  ctfe.pub:
+    sigstore:
+      uri: https://ctfe.sigstore.dev/test
+      usage: CTFE
+      status: Active
+  ctfe_2022.pub:
+    sigstore:
+      uri: https://ctfe.sigstore.dev/2022
+      usage: CTFE
+      status: Active
+  rekor.pub:
+    sigstore:
+      uri: https://rekor.sigstore.dev
+      usage: Rekor
+      status: Active
+  artifact.pub:
+    sigstore:
+      usage: Unknown
+      status: Active

--- a/pkg/keys/keys.go
+++ b/pkg/keys/keys.go
@@ -17,6 +17,7 @@ package keys
 
 import (
 	"context"
+	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/x509"
@@ -208,10 +209,17 @@ func ConstructTufKey(ctx context.Context, signer signature.Signer,
 	if err != nil {
 		return nil, err
 	}
-	switch kt := pub.(type) {
+	return ConstructTufKeyFromPublic(ctx, pub, deprecated)
+}
+
+// ConstructTufKey constructs a TUF public key from a public key
+func ConstructTufKeyFromPublic(ctx context.Context, pubKey crypto.PublicKey,
+	deprecated bool) (*data.PublicKey, error) {
+
+	switch kt := pubKey.(type) {
 	case *ecdsa.PublicKey:
 		return EcdsaTufKey(kt, deprecated)
 	default:
-		return nil, fmt.Errorf("key type %s not supported", kt)
+		return nil, fmt.Errorf("ConstructTufKeyFromPublic: key type %s not supported", kt)
 	}
 }

--- a/pkg/repo/repo.go
+++ b/pkg/repo/repo.go
@@ -186,7 +186,7 @@ func GetMetaFromStore(msg []byte, name string) (interface{}, error) {
 }
 
 // Target metadata helpers
-func SigstoreTargetMetaFromString(b []byte) (map[string]json.RawMessage, error) {
+func SigstoreTargetMetaFromString222(b []byte) (map[string]json.RawMessage, error) {
 	jsonBytes, err := kyaml.YAMLToJSON(b)
 	if err != nil {
 		return nil, err
@@ -196,6 +196,23 @@ func SigstoreTargetMetaFromString(b []byte) (map[string]json.RawMessage, error) 
 		return nil, err
 	}
 	return targetsMetaJSON, nil
+}
+
+type TargetMetaConfig struct {
+	Add map[string]json.RawMessage `json:"add"`
+	Del map[string]json.RawMessage `json:"delete"`
+}
+
+func SigstoreTargetMetaFromString(b []byte) (*TargetMetaConfig, error) {
+	jsonBytes, err := kyaml.YAMLToJSON(b)
+	if err != nil {
+		return nil, err
+	}
+	var targetsMetaJSON TargetMetaConfig
+	if err := json.Unmarshal(jsonBytes, &targetsMetaJSON); err != nil {
+		return nil, err
+	}
+	return &targetsMetaJSON, nil
 }
 
 func IsVersionedManifest(name string) bool {

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -1110,10 +1110,10 @@ func TestSignWithVersionBump(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Add a delegation
-	delegationKeyRef := stack.genKey(t, false)
+	// Add a delegation fsn
+	delegationKeyRef, delegationPubKeyRef := createTestSignVerifier(t)
 	if err := app.DelegationCmd(ctx, stack.repoDir,
-		"delegation", "path/*", true, []string{delegationKeyRef}, ""); err != nil {
+		"delegation", "path/*", true, []string{delegationPubKeyRef}, ""); err != nil {
 		t.Fatal(err)
 	}
 

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -1113,7 +1113,7 @@ func TestSignWithVersionBump(t *testing.T) {
 	// Add a delegation fsn
 	delegationKeyRef, delegationPubKeyRef := createTestSignVerifier(t)
 	if err := app.DelegationCmd(ctx, stack.repoDir,
-		"delegation", "path/*", true, []string{delegationPubKeyRef}, ""); err != nil {
+		"delegation", "path/*", true, []string{delegationPubKeyRef}, 1, ""); err != nil {
 		t.Fatal(err)
 	}
 

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -1035,16 +1035,16 @@ func TestProdTargetsConfig(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(targetFiles) != len(targetsConfig) {
-		t.Fatalf("expected %d target, got %d", len(targetsConfig), len(targetFiles))
+	if len(targetFiles) != len(targetsConfig.Add) {
+		t.Fatalf("expected %d target, got %d", len(targetsConfig.Add), len(targetFiles))
 	}
 	// Validate presence of custom metadata per configuration.
 	for name, tFiles := range targetFiles {
 		var v1, v2 interface{}
-		json.Unmarshal([]byte(targetsConfig[name]), &v1)
+		json.Unmarshal([]byte(targetsConfig.Add[name]), &v1)
 		json.Unmarshal([]byte(*tFiles.Custom), &v2)
 		if !reflect.DeepEqual(v1, v2) {
-			t.Errorf("expected custom %s, got %s", targetsConfig[name], *tFiles.Custom)
+			t.Errorf("expected custom %s, got %s", targetsConfig.Add[name], *tFiles.Custom)
 		}
 	}
 

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -1110,7 +1110,7 @@ func TestSignWithVersionBump(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Add a delegation fsn
+	// Add a delegation
 	delegationKeyRef, delegationPubKeyRef := createTestSignVerifier(t)
 	if err := app.DelegationCmd(ctx,
 		&app.DelegationOptions{
@@ -1166,4 +1166,29 @@ func TestSignWithVersionBump(t *testing.T) {
 
 	// Check delegation version bump
 	checkMetadataVersion(t, stack.repoDir, []string{"delegation.json"}, 2)
+}
+
+func TestKeyPOP(t *testing.T) {
+	ctx := context.Background()
+	keyRef, pubKeyRef := createTestSignVerifier(t)
+	challenge := "some data"
+	nonce := "not random at all"
+
+	verifier, err := app.GetVerifier(ctx, pubKeyRef)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signer, err := app.GetSigner(ctx, false, keyRef)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sig, err := app.DoKeyPOPSign(ctx, challenge, nonce, signer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = app.KeyPOPVerifyCmd(ctx, challenge, nonce, verifier, sig)
+	if err != nil {
+		t.Fatal(err)
+	}
 }

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -1112,8 +1112,16 @@ func TestSignWithVersionBump(t *testing.T) {
 
 	// Add a delegation fsn
 	delegationKeyRef, delegationPubKeyRef := createTestSignVerifier(t)
-	if err := app.DelegationCmd(ctx, stack.repoDir,
-		"delegation", "path/*", true, []string{delegationPubKeyRef}, 1, ""); err != nil {
+	if err := app.DelegationCmd(ctx,
+		&app.DelegationOptions{
+			Directory: stack.repoDir,
+			Name: "delegation",
+			Path: "path/*",
+			Terminating: true,
+			KeyRefs: []string{delegationPubKeyRef},
+			Threshold: 1,
+			Targets: "",
+		}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -1191,4 +1191,13 @@ func TestKeyPOP(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	// Verify that we got proper protection against canonicalizaton
+	// attacks
+	challenge = "some dat"
+	nonce = "anot random at all"
+	err = app.KeyPOPVerifyCmd(ctx, challenge, nonce, verifier, sig)
+	if err == nil {
+		t.Fatal("verification should fail")
+	}
 }

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -44,6 +44,7 @@ import (
 	csignature "github.com/sigstore/cosign/pkg/signature"
 	"github.com/sigstore/root-signing/cmd/tuf/app"
 	"github.com/sigstore/root-signing/pkg/keys"
+	"github.com/sigstore/root-signing/pkg/repo"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	"github.com/sigstore/sigstore/pkg/signature"
 	"github.com/theupdateframework/go-tuf"
@@ -54,7 +55,7 @@ type repoTestStack struct {
 	repoDir       string
 	hsmRootCA     *x509.Certificate
 	hsmRootSigner crypto.PrivateKey
-	targetsConfig map[string]json.RawMessage
+	targetsConfig *repo.TargetMetaConfig
 	snapshotRef   string
 	timestampRef  string
 }
@@ -73,7 +74,10 @@ func newRepoTestStack(ctx context.Context, t *testing.T) *repoTestStack {
 		repoDir:       td,
 		hsmRootCA:     rootCA,
 		hsmRootSigner: rootSigner,
-		targetsConfig: make(map[string]json.RawMessage, 0),
+		targetsConfig: &repo.TargetMetaConfig{
+			Add: map[string]json.RawMessage{},
+			Del: map[string]json.RawMessage{},
+		},
 		snapshotRef:   createTestSigner(t),
 		timestampRef:  createTestSigner(t),
 	}
@@ -84,11 +88,11 @@ func (s *repoTestStack) addTarget(t *testing.T, name, content string, custom jso
 	if err := os.WriteFile(testTarget, []byte(content), 0600); err != nil {
 		t.Fatal(err)
 	}
-	s.targetsConfig[name] = custom
+	s.targetsConfig.Add[name] = custom
 }
 
 func (s *repoTestStack) removeTarget(t *testing.T, name string) {
-	delete(s.targetsConfig, name)
+	delete(s.targetsConfig.Add, name)
 }
 
 func (s *repoTestStack) genKey(t *testing.T, hsm bool) string {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -180,6 +180,28 @@ func createTestSigner(t *testing.T) string {
 	return f.Name()
 }
 
+// Create fake key signer in testDirectory. Returns file reference to signer
+// and verifier.
+func createTestSignVerifier(t *testing.T) (string, string) {
+	keys, err := cosign.GenerateKeyPair(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	temp := t.TempDir()
+	priv, _ := os.CreateTemp(temp, "*.key")
+	pub, _ := os.CreateTemp(temp, "*.pub")
+
+	if _, err := io.Copy(priv, bytes.NewBuffer(keys.PrivateBytes)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.Copy(pub, bytes.NewBuffer(keys.PublicBytes)); err != nil {
+		t.Fatal(err)
+	}
+
+	return priv.Name(), pub.Name()
+}
+
+
 func CreateRootCA() (*x509.Certificate, crypto.PrivateKey, error) {
 	// set up our CA certificate
 	ca := &x509.Certificate{


### PR DESCRIPTION
#### Summary

Fixes: https://github.com/sigstore/root-signing/issues/601

Some comments:
To simplify operation I made proof of possession as separate commands, as that typically happens less frequent, and with multiple keys in the delegate, it will be a pain to manage the command line options for it.

- [x] Add delegate
- [x] Verify proof of possession
- [x] Create the delegate targets file
- [x] Sign the delegate target file
- [ ] Updates of the delegate target file (and targets)
- [x] Verify all e2e

#### Release Note
N/A

#### Documentation
TBD