### PR TITLE
cleanup: remove deadcode from hex public keys

### DIFF
--- a/cmd/tuf/app/add-delegation.go
+++ b/cmd/tuf/app/add-delegation.go
@@ -139,7 +139,7 @@ func DelegationCmd(ctx context.Context, opts *DelegationOptions) error {
 		if err != nil {
 			return err
 		}
-		tufKey, err := pkeys.ConstructTufKeyFromPublic(ctx, publicKey, DeprecatedEcdsaFormat)
+		tufKey, err := pkeys.ConstructTufKeyFromPublic(ctx, publicKey)
 		if err != nil {
 			return err
 		}

--- a/cmd/verify/app/repository.go
+++ b/cmd/verify/app/repository.go
@@ -37,8 +37,8 @@ import (
 	"github.com/theupdateframework/go-tuf/data"
 	"github.com/theupdateframework/go-tuf/verify"
 
-	// Allow deprecated ECDSA key formats for v5.
-	// TODO(https://github.com/sigstore/root-signing/issues/381): Cleanup after v5
+	// Allow deprecated ECDSA key formats.
+	// We still allow this so that we may verify against the original root.
 	_ "github.com/theupdateframework/go-tuf/pkg/deprecated/set_ecdsa"
 )
 

--- a/pkg/keys/keys_test.go
+++ b/pkg/keys/keys_test.go
@@ -160,19 +160,11 @@ func TestToSigningKey(t *testing.T) {
 				t.Errorf("unexpected error generating signing key (%s): %s", tt.name, err)
 			}
 			if tt.expectSuccess {
-				hexPubKey, err := EcdsaTufKey(key.PublicKey, true)
-				if err != nil {
-					t.Errorf("unexpected error generating hex TUF public key: %s", err)
-				}
-				pemPubKey, err := EcdsaTufKey(key.PublicKey, false)
+				pemPubKey, err := EcdsaTufKey(key.PublicKey)
 				if err != nil {
 					t.Errorf("unexpected error generating PEM TUF public key: %s", err)
 				}
-				// True to get verifiers.
-				_, err = keys.GetVerifier(hexPubKey)
-				if err != nil {
-					t.Errorf("unexpected error getting TUF hex ecdsa verifier: %s", err)
-				}
+				// Try to get verifiers.
 				_, err = keys.GetVerifier(pemPubKey)
 				if err != nil {
 					t.Errorf("unexpected error getting TUF PEM ecdsa verifier: %s", err)
@@ -192,7 +184,7 @@ func TestGetSigningKey(t *testing.T) {
 	}
 
 	t.Run("valid signing key with PEM", func(t *testing.T) {
-		signingKeyPem, err := ConstructTufKey(ctx, signingKey, false)
+		signingKeyPem, err := ConstructTufKey(ctx, signingKey)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -204,26 +196,6 @@ func TestGetSigningKey(t *testing.T) {
 		pemKey := keys.NewEcdsaVerifier()
 		if err := pemKey.UnmarshalPublicKey(signingKeyPem); err != nil {
 			t.Errorf("unexpected error getting TUF PEM ecdsa verifier: %s", err)
-		}
-	})
-	t.Run("valid signing key with hex", func(t *testing.T) {
-		signingKeyHex, err := ConstructTufKey(ctx, signingKey, true)
-		if err != nil {
-			t.Fatal(err)
-		}
-		_, err = keys.GetVerifier(signingKeyHex)
-		if err != nil {
-			t.Fatalf("unexpected error getting hex PEM ecdsa verifier: %s", err)
-		}
-		// Try with explicit verifier.
-		hexKey := keys.NewDeprecatedEcdsaVerifier()
-		if err := hexKey.UnmarshalPublicKey(signingKeyHex); err != nil {
-			t.Errorf("unexpected error unmarshalling with  TUF hex ecdsa verifier: %s", err)
-		}
-		// Fails with other verifier.
-		pemKey := keys.NewEcdsaVerifier()
-		if err := pemKey.UnmarshalPublicKey(signingKeyHex); err == nil {
-			t.Errorf("expected error unmarshalling with TUF PEM ecdsa verifier: %s", err)
 		}
 	})
 }

--- a/scripts/step-2.sh
+++ b/scripts/step-2.sh
@@ -38,9 +38,7 @@ checkout_branch
 read -n1 -r -s -p "Insert your Yubikey, then press any key to continue...\n"
 
 # Sign the root and targets with hardware key
-# TODO(https://github.com/sigstore/root-signing/issues/381):
-# Adding the explicit deprecated flag can be removed after v5 root-signing
-./tuf sign -repository "$REPO" -roles root -roles targets -sk -add-deprecated true
+./tuf sign -repository "$REPO" -roles root -roles targets -sk
 
 # Ask user to remove key (and replace with SSH security key)
 read -n1 -r -s -p "Remove your Yubikey, then press any key to continue...\n"

--- a/scripts/step-3.sh
+++ b/scripts/step-3.sh
@@ -45,10 +45,10 @@ checkout_branch
 
 # Snapshot and sign the snapshot with snapshot kms key
 ./tuf snapshot -repository "$REPO"
-./tuf sign -repository "$REPO" -roles snapshot -key "${SNAPSHOT_KEY}" -add-deprecated=true
+./tuf sign -repository "$REPO" -roles snapshot -key "${SNAPSHOT_KEY}"
 
 # Timestamp and sign the timestamp with timestamp kms key
 ./tuf timestamp -repository "$REPO"
-./tuf sign -repository "$REPO" -roles timestamp -key "${TIMESTAMP_KEY}" -add-deprecated=true
+./tuf sign -repository "$REPO" -roles timestamp -key "${TIMESTAMP_KEY}"
 
 commit_and_push_changes snapshot-timestamp

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -78,8 +78,8 @@ func newRepoTestStack(ctx context.Context, t *testing.T) *repoTestStack {
 			Add: map[string]json.RawMessage{},
 			Del: map[string]json.RawMessage{},
 		},
-		snapshotRef:   createTestSigner(t),
-		timestampRef:  createTestSigner(t),
+		snapshotRef:  createTestSigner(t),
+		timestampRef: createTestSigner(t),
 	}
 }
 
@@ -137,7 +137,7 @@ func (s *repoTestStack) getManifest(t *testing.T, manifest string) json.RawMessa
 	return md
 }
 
-func (s *repoTestStack) snapshot(t *testing.T, deprecated bool) {
+func (s *repoTestStack) snapshot(t *testing.T) {
 	if err := app.SnapshotCmd(s.ctx, s.repoDir); err != nil {
 		t.Fatalf("expected Snapshot command to pass, got err: %s", err)
 	}
@@ -145,12 +145,12 @@ func (s *repoTestStack) snapshot(t *testing.T, deprecated bool) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := app.SignCmd(s.ctx, s.repoDir, []string{"snapshot"}, snapshotSigner, false, deprecated); err != nil {
+	if err := app.SignCmd(s.ctx, s.repoDir, []string{"snapshot"}, snapshotSigner, false); err != nil {
 		t.Fatal(err)
 	}
 }
 
-func (s *repoTestStack) timestamp(t *testing.T, deprecated bool) {
+func (s *repoTestStack) timestamp(t *testing.T) {
 	if err := app.TimestampCmd(s.ctx, s.repoDir); err != nil {
 		t.Fatalf("expected timestamp command to pass, got err: %s", err)
 	}
@@ -158,7 +158,7 @@ func (s *repoTestStack) timestamp(t *testing.T, deprecated bool) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := app.SignCmd(s.ctx, s.repoDir, []string{"timestamp"}, timestampSigner, false, deprecated); err != nil {
+	if err := app.SignCmd(s.ctx, s.repoDir, []string{"timestamp"}, timestampSigner, false); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -204,7 +204,6 @@ func createTestSignVerifier(t *testing.T) (string, string) {
 
 	return priv.Name(), pub.Name()
 }
-
 
 func CreateRootCA() (*x509.Certificate, crypto.PrivateKey, error) {
 	// set up our CA certificate


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Fixes https://github.com/sigstore/root-signing/issues/381

We no longer need to handle hex ECDSA keys, except in the client verification path when verifying against older roots (commented). All references in the CLI can be removed, since we no longer need to sign or read from hex keys.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->