### PR TITLE
feat: use ceremony branches for initializing root-signing ceremony

### DIFF
--- a/.github/workflows/initialize.yml
+++ b/.github/workflows/initialize.yml
@@ -41,6 +41,23 @@ on:
         type: boolean
 
 jobs:
+  check_branch:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        with:
+          fetch-depth: 0
+      - name: Check if remote branch exists
+        env:
+          BRANCH: ${{ inputs.branch }}
+        run: |
+          branch_exists=$(git ls-remote --heads upstream ${BRANCH})
+
+          if [[ -z ${branch_exists} ]]; then
+            echo "Staging root branch ${BRANCH} does not exist: has a maintainer created one?"
+            exit 1
+          fi
+
   init_root:
     runs-on: ubuntu-20.04
     permissions:

--- a/.github/workflows/initialize.yml
+++ b/.github/workflows/initialize.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Stage a new root and targets
+name: Stage a new root and targets on a new branch
 
 permissions: read-all
 
@@ -21,12 +21,16 @@ permissions: read-all
 on:
   workflow_dispatch:
     inputs:
+      branch:
+        description: 'The branch to stage changes against, generally ceremony/YYYY-MM-DD'
+        required: true
+        type: string
       revoke_key:
         description: 'If provided, revokes the given HSM key, identified by the serial number'
         required: false
         type: string
-      prev_repo:
-        description: 'Chains the new root from this previous repository'
+      repo:
+        description: 'The repository in which to stage a new root and targets'
         required: false
         default: repository/
         type: string
@@ -51,7 +55,8 @@ jobs:
           echo "GITHUB_USER=${{ github.actor }}" >> $GITHUB_ENV
           echo "SNAPSHOT_KEY=gcpkms://projects/sigstore-root-signing/locations/global/keyRings/root/cryptoKeys/snapshot" >> $GITHUB_ENV
           echo "TIMESTAMP_KEY=gcpkms://projects/sigstore-root-signing/locations/global/keyRings/root/cryptoKeys/timestamp" >> $GITHUB_ENV
-          echo "PREV_REPO=${{ inputs.prev_repo }}" >> $GITHUB_ENV
+          echo "REPO=${{ inputs.repo }}" >> $GITHUB_ENV
+          echo "BRANCH=${{ inputs.branch }}" >> $GITHUB_ENV
           # Note: we set LOCAL=1 because we manually push the changes in the next job.
           echo "LOCAL=1" >> $GITHUB_ENV
       - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0

--- a/scripts/step-1.5.sh
+++ b/scripts/step-1.5.sh
@@ -38,11 +38,6 @@ if [ -z "$SNAPSHOT_KEY" ]; then
 fi
 # TODO(https://github.com/sigstore/root-signing/issues/398):
 # Add any necessary delegation keys
-# Repo options
-if [ -z "$PREV_REPO" ]; then
-    echo "Set PREV_REPO"
-    exit
-fi
 
 # Dump the git state and clean-up
 print_git_state
@@ -51,9 +46,6 @@ clean_state
 # Checkout the working branch
 checkout_branch
 
-# Copy the previous keys and repository into the new repository.
-mkdir -p "${REPO}"/staged/targets
-cp -r "${PREV_REPO}"/* "${REPO}"
 # Remove a key by ID that need to be removed from the root keyholders
 if [[ -n $1 ]]; then
     echo "Removing key: $1"
@@ -63,6 +55,6 @@ fi
 # Setup the root and targets
 ./tuf init -repository "$REPO" \
     -targets "$(pwd)"/targets -target-meta config/targets-metadata.yml \
-    -snapshot "${SNAPSHOT_KEY}" -timestamp "${TIMESTAMP_KEY}" -previous "${PREV_REPO}"
+    -snapshot "${SNAPSHOT_KEY}" -timestamp "${TIMESTAMP_KEY}"
 
 commit_and_push_changes setup-root

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -23,7 +23,7 @@ check_user() {
 
 set_repository() {
     if [ -z "$REPO" ]; then
-        REPO=$(pwd)/ceremony/$(date '+%Y-%m-%d')
+        REPO=$(pwd)/repository
     fi
     echo "Using REPO $REPO"
 }
@@ -89,10 +89,10 @@ commit_and_push_changes() {
     fi
 
     # Create a commit
-    git checkout -b "$1-${REPO: -10}"
-    git add ceremony/ repository/
+    git checkout -b "$1-${BRANCH: -10}"
+    git add repository/
     git commit -s -a -m "$1 for ${GITHUB_USER}"
-    git push -f origin "$1-${REPO: -10}"
+    git push -f origin "$1-${BRANCH: -10}"
 
     # Open the browser
     GITHUB_URL=$(git remote -v | awk '/^upstream/{print $2}'| head -1 | sed -Ee 's#(git@|git://)#https://#' -e 's@com:@com/@' -e 's#\.git$##')

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -158,7 +158,7 @@ func TestInitCmd(t *testing.T) {
 	}
 
 	// Initialize succeeds.
-	if err := app.InitCmd(ctx, stack.repoDir, "", 1,
+	if err := app.InitCmd(ctx, stack.repoDir, 1,
 		stack.targetsConfig, stack.repoDir, stack.snapshotRef, stack.timestampRef); err != nil {
 		t.Fatal(err)
 	}
@@ -177,7 +177,7 @@ func TestSignRootTargets(t *testing.T) {
 	rootKeyRef := stack.genKey(t, true)
 
 	// Initialize with 1 succeeds.
-	if err := app.InitCmd(ctx, stack.repoDir, "", 1,
+	if err := app.InitCmd(ctx, stack.repoDir, 1,
 		stack.targetsConfig, stack.repoDir, stack.snapshotRef, stack.timestampRef); err != nil {
 		t.Fatal(err)
 	}
@@ -221,7 +221,7 @@ func TestSnapshotUnvalidatedFails(t *testing.T) {
 	_ = stack.genKey(t, true)
 
 	// Initialize with threshold 1 succeeds.
-	if err := app.InitCmd(ctx, stack.repoDir, "", 1,
+	if err := app.InitCmd(ctx, stack.repoDir, 1,
 		stack.targetsConfig, stack.repoDir, stack.snapshotRef, stack.timestampRef); err != nil {
 		t.Fatal(err)
 	}
@@ -290,7 +290,7 @@ func TestPublishSuccess(t *testing.T) {
 	rootKeyRef := stack.genKey(t, true)
 
 	// Initialize with 1 succeeds.
-	if err := app.InitCmd(ctx, stack.repoDir, "", 1,
+	if err := app.InitCmd(ctx, stack.repoDir, 1,
 		stack.targetsConfig, stack.repoDir, stack.snapshotRef, stack.timestampRef); err != nil {
 		t.Fatal(err)
 	}
@@ -348,7 +348,7 @@ func TestRotateRootKey(t *testing.T) {
 	rootKeyRef2 := stack.genKey(t, true)
 
 	// Initialize succeeds
-	if err := app.InitCmd(ctx, stack.repoDir, "", 1,
+	if err := app.InitCmd(ctx, stack.repoDir, 1,
 		stack.targetsConfig, stack.repoDir, stack.snapshotRef, stack.timestampRef); err != nil {
 		t.Fatal(err)
 	}
@@ -397,7 +397,7 @@ func TestRotateRootKey(t *testing.T) {
 	rootKeyRef3 := stack.genKey(t, true)
 
 	// Create a new root.
-	if err := app.InitCmd(ctx, stack.repoDir, stack.repoDir, 1,
+	if err := app.InitCmd(ctx, stack.repoDir, 1,
 		stack.targetsConfig, stack.repoDir, stack.snapshotRef, stack.timestampRef); err != nil {
 		t.Fatal(err)
 	}
@@ -454,7 +454,7 @@ func TestRotateTarget(t *testing.T) {
 	rootKeyRef := stack.genKey(t, true)
 
 	// Initialize succeeds.
-	if err := app.InitCmd(ctx, stack.repoDir, "", 1,
+	if err := app.InitCmd(ctx, stack.repoDir, 1,
 		stack.targetsConfig, stack.repoDir, stack.snapshotRef, stack.timestampRef); err != nil {
 		t.Fatal(err)
 	}
@@ -495,7 +495,7 @@ func TestRotateTarget(t *testing.T) {
 	stack.addTarget(t, "bar.txt", "abcdef", nil)
 
 	// Initialize succeeds.
-	if err := app.InitCmd(ctx, stack.repoDir, stack.repoDir, 1,
+	if err := app.InitCmd(ctx, stack.repoDir, 1,
 		stack.targetsConfig, stack.repoDir, stack.snapshotRef, stack.timestampRef); err != nil {
 		t.Fatal(err)
 	}
@@ -541,7 +541,7 @@ func TestConsistentSnapshotFlip(t *testing.T) {
 
 	// Initialize succeeds with consistent snapshot off.
 	app.ConsistentSnapshot = false
-	if err := app.InitCmd(ctx, stack.repoDir, "", 1,
+	if err := app.InitCmd(ctx, stack.repoDir, 1,
 		stack.targetsConfig, stack.repoDir, stack.snapshotRef, stack.timestampRef); err != nil {
 		t.Fatal(err)
 	}
@@ -580,7 +580,7 @@ func TestConsistentSnapshotFlip(t *testing.T) {
 	// Flip consistent snapshot on.
 	app.ConsistentSnapshot = true
 	// Initialize succeeds.
-	if err := app.InitCmd(ctx, stack.repoDir, stack.repoDir, 1,
+	if err := app.InitCmd(ctx, stack.repoDir, 1,
 		stack.targetsConfig, stack.repoDir, stack.snapshotRef, stack.timestampRef); err != nil {
 		t.Fatal(err)
 	}
@@ -640,7 +640,7 @@ func TestSnapshotKeyRotate(t *testing.T) {
 	rootKeyRef := stack.genKey(t, true)
 
 	// Initialize succeeds.
-	if err := app.InitCmd(ctx, stack.repoDir, "", 1,
+	if err := app.InitCmd(ctx, stack.repoDir, 1,
 		stack.targetsConfig, stack.repoDir, stack.snapshotRef, stack.timestampRef); err != nil {
 		t.Fatal(err)
 	}
@@ -683,7 +683,7 @@ func TestSnapshotKeyRotate(t *testing.T) {
 	// Now rotate the snapshot signer out.
 	stack.snapshotRef = createTestSigner(t)
 	// Initialize succeeds.
-	if err := app.InitCmd(ctx, stack.repoDir, stack.repoDir, 1,
+	if err := app.InitCmd(ctx, stack.repoDir, 1,
 		stack.targetsConfig, stack.repoDir, stack.snapshotRef, stack.timestampRef); err != nil {
 		t.Fatal(err)
 	}
@@ -741,7 +741,7 @@ func TestProdTargetsConfig(t *testing.T) {
 	}
 
 	// Initialize succeeds.
-	if err := app.InitCmd(ctx, stack.repoDir, "", 1,
+	if err := app.InitCmd(ctx, stack.repoDir, 1,
 		targetsConfig, targetsDir, stack.snapshotRef, stack.timestampRef); err != nil {
 		t.Fatal(err)
 	}
@@ -801,7 +801,7 @@ func TestDelegationsClearedOnInit(t *testing.T) {
 	rootKeyRef := stack.genKey(t, true)
 
 	// Initialize succeeds.
-	if err := app.InitCmd(ctx, stack.repoDir, "", 1,
+	if err := app.InitCmd(ctx, stack.repoDir, 1,
 		stack.targetsConfig, stack.repoDir, stack.snapshotRef, stack.timestampRef); err != nil {
 		t.Fatal(err)
 	}
@@ -836,7 +836,7 @@ func TestSignWithVersionBump(t *testing.T) {
 	rootKeyRef := stack.genKey(t, true)
 
 	// Initialize succeeds.
-	if err := app.InitCmd(ctx, stack.repoDir, "", 1,
+	if err := app.InitCmd(ctx, stack.repoDir, 1,
 		stack.targetsConfig, stack.repoDir, stack.snapshotRef, stack.timestampRef); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Part of https://github.com/sigstore/root-signing/issues/453

This change does the following:
* Renames `staging-initialize.yml` to `initialize.yml`. This always confused me. This workflow initializes a new root-signing ceremony.
* Adds a branch option to the `initialize.yml`. This gets used as the env var `BRANCH` where the changes will occur, and the PRs will be opened against.
* Removes references to `PREV_REPO`. The previous repository used to be the top-level `repository/` since the current staged repository was disjoint from it. Now we act on the same input repository. 
* Updates the documentation (only for the relevant changes here).
