### PR TITLE
Script for verifying delegation POP

### DIFF
--- a/.github/workflows/delegation-pop-verify.yml
+++ b/.github/workflows/delegation-pop-verify.yml
@@ -16,13 +16,11 @@
 name: Verify POP for a delegation
 
 on:
-  workflow_dispatch:
-  push:
-    branches: [main]
-    paths:
-      - 'repository/**'
   pull_request:
-    branches: [main]
+    branches:
+      - 'ceremony/**'
+      - 'test-ceremony/**'
+      - 'test-delegation/**'
 
 jobs:
   verify:
@@ -36,7 +34,12 @@ jobs:
       PR_NUMBER: ${{ github.event.pull_request.number }}
       ISSUE_REPOSITORY: sigstore/root-signing
     steps:
+      - name: Setup go
+        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
+        with:
+          go-version: 1.19
+          check-latest: true
       - name: build
         run: make tuf
       - name: Veriry POP
-        run: ./github/workflows/script/dpop-wrapper.sh "${{ github.event.pull_request.title }}" "${{ gitnub.event.pull_request.body }}"
+        run: ./github/workflows/script/dpop-wrapper.sh "${{ github.event.pull_request.title }}"

--- a/.github/workflows/delegation-pop-verify.yml
+++ b/.github/workflows/delegation-pop-verify.yml
@@ -1,0 +1,34 @@
+#
+# Copyright 2023 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Verify POP for a delegation
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'repository/**'
+  pull_request:
+    branches: [main]
+
+jobs:
+  verify:
+    if: startsWith(github.event.pull_request.title, 'feat: add-delegtion for/')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Veriry POP
+        run: ./script/dpop-wrapper.sh "${{ github.event.pull_request.title }}" "${{ gitnub.event.pull_request.body }}"

--- a/.github/workflows/delegation-pop-verify.yml
+++ b/.github/workflows/delegation-pop-verify.yml
@@ -41,5 +41,5 @@ jobs:
           check-latest: true
       - name: build
         run: make tuf
-      - name: Veriry POP
+      - name: Verify POP
         run: ./github/workflows/script/dpop-wrapper.sh "${{ github.event.pull_request.title }}"

--- a/.github/workflows/delegation-pop-verify.yml
+++ b/.github/workflows/delegation-pop-verify.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   verify:
-    if: startsWith(github.event.pull_request.title, 'feat: add-delegtion for ')
+    if: startsWith(github.event.pull_request.title, 'feat add-delegtion for ')
     runs-on: ubuntu-latest
     permissions:
       contents: 'write'

--- a/.github/workflows/delegation-pop-verify.yml
+++ b/.github/workflows/delegation-pop-verify.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   verify:
-    if: startsWith(github.event.pull_request.title, 'feat: add-delegtion for/')
+    if: startsWith(github.event.pull_request.title, 'feat: add-delegtion for ')
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/delegation-pop-verify.yml
+++ b/.github/workflows/delegation-pop-verify.yml
@@ -26,9 +26,7 @@ on:
 
 jobs:
   verify:
-    # yamllint disable
-    if: ${{ startsWith(github.event.pull_request.title, 'feat: add-delegtion for ') }}
-    # yamllint enable
+    if: ${{ startsWith(github.event.pull_request.title, 'feat/add-delegtion for ') }}
     runs-on: ubuntu-latest
     permissions:
       contents: 'write'

--- a/.github/workflows/delegation-pop-verify.yml
+++ b/.github/workflows/delegation-pop-verify.yml
@@ -28,7 +28,14 @@ jobs:
   verify:
     if: startsWith(github.event.pull_request.title, 'feat: add-delegtion for ')
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: 'write'
+      pull-requests: 'read'
+    env:
+      GITHUB_TOKEN: ${{ secrets.SIGSTORE_REVIEW_BOT_FINE_GRAINED_PAT }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
     steps:
+      - name: build
+        run: make tuf
       - name: Veriry POP
-        run: ./script/dpop-wrapper.sh "${{ github.event.pull_request.title }}" "${{ gitnub.event.pull_request.body }}"
+        run: ./github/workflows/script/dpop-wrapper.sh "${{ github.event.pull_request.title }}" "${{ gitnub.event.pull_request.body }}"

--- a/.github/workflows/delegation-pop-verify.yml
+++ b/.github/workflows/delegation-pop-verify.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   verify:
-    if: startsWith(github.event.pull_request.title, 'feat add-delegtion for ')
+    if: startsWith(github.event.pull_request.title, 'feat: add-delegtion for ')
     runs-on: ubuntu-latest
     permissions:
       contents: 'write'
@@ -34,6 +34,7 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.SIGSTORE_REVIEW_BOT_FINE_GRAINED_PAT }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
+      ISSUE_REPOSITORY: sigstore/root-signing
     steps:
       - name: build
         run: make tuf

--- a/.github/workflows/delegation-pop-verify.yml
+++ b/.github/workflows/delegation-pop-verify.yml
@@ -26,7 +26,9 @@ on:
 
 jobs:
   verify:
-    if: startsWith(github.event.pull_request.title, 'feat: add-delegtion for ')
+    # yamllint disable
+    if: ${{ startsWith(github.event.pull_request.title, 'feat: add-delegtion for ') }}
+    # yamllint enable
     runs-on: ubuntu-latest
     permissions:
       contents: 'write'

--- a/.github/workflows/scripts/dpop-wrapper.sh
+++ b/.github/workflows/scripts/dpop-wrapper.sh
@@ -25,9 +25,8 @@ TITLE=$1
 BODY=$2
 
 DELEGATION=$(echo "${TITLE}" | sed -E 's/(.+) for (.+)/\2/')
-SIG=$(echo "${BODY}" | sed -E 's/(.*)Signature: (.+)/\2/')
 OUTPUT=$(mktemp)
-./scripts/dpop-verify.sh "${DELEGATION}" "${SIG}" 2>&1 | tee "${OUTPUT}"
+./scripts/dpop-verify.sh "${DELEGATION}" 2>&1 | tee "${OUTPUT}"
 
 # If we made it here, signature verification was successful.
 # Add a comment with the output

--- a/.github/workflows/scripts/dpop-wrapper.sh
+++ b/.github/workflows/scripts/dpop-wrapper.sh
@@ -31,4 +31,5 @@ OUTPUT=$(mktemp)
 
 # If we made it here, signature verification was successful.
 # Add a comment with the output
-GH_TOKEN=${GITHUB_TOKEN} gh -R \
+GH_TOKEN=${GITHUB_TOKEN} gh -R "${ISSUE_REPOSITORY}" \
+        pr comment "${PR_NUMBER}" -F "${OUTPUT}"

--- a/.github/workflows/scripts/dpop-wrapper.sh
+++ b/.github/workflows/scripts/dpop-wrapper.sh
@@ -22,7 +22,6 @@ set -euo pipefail
 # It then calls the real script which will invoke the actual verification.
 #
 TITLE=$1
-BODY=$2
 
 DELEGATION=$(echo "${TITLE}" | sed -E 's/(.+) for (.+)/\2/')
 OUTPUT=$(mktemp)

--- a/.github/workflows/scripts/dpop-wrapper.sh
+++ b/.github/workflows/scripts/dpop-wrapper.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#
+# Copyright 2023 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -u
+set -e
+
+#
+# This is just a thin wrapper that takes on the input from a pull request
+# and parses out the name of the delegation and the signature.
+# It then calls the real script which will invoke the actual verification.
+#
+TITLE=$1
+BODY=$2
+
+DELEGATION=`echo ${TITLE} | sed -E 's/(.+) for (.+)/\2/'`
+SIG=`echo ${BODY} | sed -E 's/(.*)Signature: (.+)/\2/'`
+# Per https://github.com/sigstore/root-signing/pull/618
+# this should be known a priori
+REPO=./xyz/repository

--- a/.github/workflows/scripts/dpop-wrapper.sh
+++ b/.github/workflows/scripts/dpop-wrapper.sh
@@ -24,10 +24,10 @@ set -euo pipefail
 TITLE=$1
 BODY=$2
 
-DELEGATION=$(echo ${TITLE} | sed -E 's/(.+) for (.+)/\2/')
-SIG=$(echo ${BODY} | sed -E 's/(.*)Signature: (.+)/\2/')
+DELEGATION=$(echo "${TITLE}" | sed -E 's/(.+) for (.+)/\2/')
+SIG=$(echo "${BODY}" | sed -E 's/(.*)Signature: (.+)/\2/')
 OUTPUT=$(mktemp)
-./scripts/dpop-verify.sh "${DELEGATION}" "${SIG}" 2>&1 | tee ${OUTPUT}
+./scripts/dpop-verify.sh "${DELEGATION}" "${SIG}" 2>&1 | tee "${OUTPUT}"
 
 # If we made it here, signature verification was successful.
 # Add a comment with the output

--- a/.github/workflows/scripts/dpop-wrapper.sh
+++ b/.github/workflows/scripts/dpop-wrapper.sh
@@ -25,8 +25,12 @@ set -e
 TITLE=$1
 BODY=$2
 
-DELEGATION=`echo ${TITLE} | sed -E 's/(.+) for (.+)/\2/'`
-SIG=`echo ${BODY} | sed -E 's/(.*)Signature: (.+)/\2/'`
+DELEGATION=$(echo ${TITLE} | sed -E 's/(.+) for (.+)/\2/')
+SIG=$(echo ${BODY} | sed -E 's/(.*)Signature: (.+)/\2/')
 # Per https://github.com/sigstore/root-signing/pull/618
 # this should be known a priori
 REPO=./xyz/repository
+
+export REPO
+
+../../../scripts/dpop-verify.sh "${DELEGATION}" "${SIG}"

--- a/.github/workflows/scripts/dpop-wrapper.sh
+++ b/.github/workflows/scripts/dpop-wrapper.sh
@@ -14,8 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -u
-set -e
+set -euo pipefail
 
 #
 # This is just a thin wrapper that takes on the input from a pull request
@@ -27,10 +26,9 @@ BODY=$2
 
 DELEGATION=$(echo ${TITLE} | sed -E 's/(.+) for (.+)/\2/')
 SIG=$(echo ${BODY} | sed -E 's/(.*)Signature: (.+)/\2/')
-# Per https://github.com/sigstore/root-signing/pull/618
-# this should be known a priori
-REPO=./xyz/repository
+OUTPUT=$(mktemp)
+./scripts/dpop-verify.sh "${DELEGATION}" "${SIG}" 2>&1 | tee ${OUTPUT}
 
-export REPO
-
-../../../scripts/dpop-verify.sh "${DELEGATION}" "${SIG}"
+# If we made it here, signature verification was successful.
+# Add a comment with the output
+GH_TOKEN=${GITHUB_TOKEN} gh -R \

--- a/cmd/tuf/app/key-pop-verify.go
+++ b/cmd/tuf/app/key-pop-verify.go
@@ -35,7 +35,7 @@ import (
 	"github.com/theupdateframework/go-tuf/data"
 )
 
-const targetsMeta = "targets.json"
+const topLevelTargetsFilename = "targets.json"
 
 func KeyPOPVerify() *ffcli.Command {
 	var (
@@ -100,11 +100,11 @@ func KeyPOPVerify() *ffcli.Command {
 
 func GetKeyIDForRole(directory, role string) (string, error) {
 	store := tuf.FileSystemStore(directory, nil)
-	signed, err := repo.GetSignedMeta(store, targetsMeta)
+	signed, err := repo.GetSignedMeta(store, topLevelTargetsFilename)
 	if err != nil {
 		return "", err
 	}
-	meta, err := repo.GetMetaFromStore(signed.Signed, targetsMeta)
+	meta, err := repo.GetMetaFromStore(signed.Signed, topLevelTargetsFilename)
 	if err != nil {
 		return "", err
 	}
@@ -128,11 +128,11 @@ func GetKeyIDForRole(directory, role string) (string, error) {
 
 func GetPublicKeyFromID(directory, keyid string) (crypto.PublicKey, error) {
 	store := tuf.FileSystemStore(directory, nil)
-	signed, err := repo.GetSignedMeta(store, targetsMeta)
+	signed, err := repo.GetSignedMeta(store, topLevelTargetsFilename)
 	if err != nil {
 		return nil, err
 	}
-	meta, err := repo.GetMetaFromStore(signed.Signed, targetsMeta)
+	meta, err := repo.GetMetaFromStore(signed.Signed, topLevelTargetsFilename)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/keys/keys.go
+++ b/pkg/keys/keys.go
@@ -50,8 +50,12 @@ type SigningKey struct {
 	KeyCert      *x509.Certificate
 }
 
-type EcdsaPublic struct {
-	PublicKey data.HexBytes `json:"public"`
+type KeyValue struct {
+	PublicKey string `json:"public"`
+}
+
+func (kv *KeyValue) Unmarshal(pubKey *data.PublicKey) error {
+	return json.Unmarshal(pubKey.Value, kv)
 }
 
 func ToCert(pemBytes []byte) (*x509.Certificate, error) {

--- a/scripts/dpop-verify.sh
+++ b/scripts/dpop-verify.sh
@@ -19,14 +19,14 @@ set -o errexit
 set -o xtrace
 set -u
 
-BRANCH=`git rev-parse --abbrev-ref HEAD`
-FORK_POINT=`git merge-base --fork-point origin/main ${BRANCH}`
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+FORK_POINT=$(git merge-base --fork-point origin/main ${BRANCH})
 DELEGATION=$1
 SIG=$2
 
 ./tuf key-pop-verify \
-      -role ${DELEGATION}
-      -challenge ${DELEGATION} \
-      -nonce ${FORK_POINT} \
-      -repository ${REPO} \
-      -sig ${SIG}
+      -role "${DELEGATION}" \
+      -challenge "${DELEGATION}" \
+      -nonce "${FORK_POINT}" \
+      -repository "${REPO}" \
+      -sig "${SIG}"

--- a/scripts/dpop-verify.sh
+++ b/scripts/dpop-verify.sh
@@ -23,7 +23,14 @@ BRANCH=$(git rev-parse --abbrev-ref HEAD)
 FORK_POINT=$(git merge-base --fork-point origin/main "${BRANCH}")
 REPO=./repository
 DELEGATION=$1
-SIG=$2
+SIG_FILE="${REPO}"/staged/"${FORK_POINT}".sig
+
+if [ ! -f "${SIG_FILE}" ]; then
+    echo Expected signature file: "${SIG_FILE}" not found
+    exit 1
+fi
+
+SIG=$(cat "${SIG_FILE}")
 
 ./tuf key-pop-verify \
       -role "${DELEGATION}" \

--- a/scripts/dpop-verify.sh
+++ b/scripts/dpop-verify.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#
+# Copyright 2023 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Print all commands and stop on errors
+set -o errexit
+set -o xtrace
+set -u
+
+BRANCH=`git rev-parse --abbrev-ref HEAD`
+FORK_POINT=`git merge-base --fork-point origin/main ${BRANCH}`
+DELEGATION=$1
+SIG=$2
+
+./tuf key-pop-verify \
+      -role ${DELEGATION}
+      -challenge ${DELEGATION} \
+      -nonce ${FORK_POINT} \
+      -repository ${REPO} \
+      -sig ${SIG}

--- a/scripts/dpop-verify.sh
+++ b/scripts/dpop-verify.sh
@@ -21,6 +21,7 @@ set -u
 
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
 FORK_POINT=$(git merge-base --fork-point origin/main ${BRANCH})
+REPO=./repository
 DELEGATION=$1
 SIG=$2
 

--- a/scripts/dpop-verify.sh
+++ b/scripts/dpop-verify.sh
@@ -20,7 +20,7 @@ set -o xtrace
 set -u
 
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
-FORK_POINT=$(git merge-base --fork-point origin/main ${BRANCH})
+FORK_POINT=$(git merge-base --fork-point origin/main "${BRANCH}")
 REPO=./repository
 DELEGATION=$1
 SIG=$2


### PR DESCRIPTION
Signed-off-by: Fredrik Skogman <kommendorkapten@github.com>

#### Summary
Adds a workflow that is executed on PR that adds a delegate, it runs the key POP verification commands and fails if the signature does not match the expected.

#### Release Note
N/A

#### Documentation
- [ ] Update the docs on the expected PR title
- [ ] Document how to generate the POP and how to include it in the PR