### PR TITLE
fix: fix the push job to handle repository changes

### DIFF
--- a/.github/workflows/initialize.yml
+++ b/.github/workflows/initialize.yml
@@ -110,8 +110,8 @@ jobs:
       - name: Upload new repository
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
-          name: ceremony
-          path: ceremony/
+          name: ${{ inputs.repo }}
+          path: ${{ inputs.repo }}
           retention-days: 5
 
   push:
@@ -126,32 +126,28 @@ jobs:
           fetch-depth: 0
       - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v2.1.0
         with:
-          name: ceremony
-          path: ceremony/
+          name: ${{ inputs.repo }}
+          path: ${{ inputs.repo }}
       # Detect new version and expiration to add to the PR description.
       - name: Detect new version
+        env:
+          REPO: ${{ inputs.repo }}
         run: |
-          # Detects the ceremony date.
-          DATE=$(git status -s | grep --regexp=ceremony/* | cut -f2 -d /)
-          echo "DATE=$DATE" >> $GITHUB_ENV
-
           # Detects the new root version.
-          VERSION=$(cat ceremony/${DATE}/staged/root.json | jq -r '.signed.version')
+          VERSION=$(cat ${REPO}/staged/root.json | jq -r '.signed.version')
           echo "VERSION=$VERSION" >> $GITHUB_ENV
 
       # Create commits
       - name: Create commits
+        env:
+          REPO: ${{ inputs.repo }}
         run: |
           # Set identity.
           git config --global user.email "noreply@github.com"
           git config --global user.name "GitHub"
 
-          # First commit the old repository data.
-          git add ceremony/"${DATE}"/repository/ ceremony/"${DATE}"/keys/
-          git commit -s -m "Copy current repository metadata and keys"
-
-          # Now put the staged metadata into a second commit
-          git add ceremony/"${DATE}"/staged/
+          # Commit the REPO changes
+          git add ${REPO}
           git commit -s -m "Add staged repository metadata"
 
       # Open pull request changes


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

See run https://github.com/sigstore/root-signing/actions/runs/4177011573/jobs/7234043657

I didn't handle the `push` job migration to using `repository/` instead of `ceremony/`

We no longer need to create two commits, because the repository is working on the existing data so the single commit will be the diff!

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->