### PR TITLE
feat: add trusted root to targets metadata

### DIFF
--- a/.github/workflows/staging-snapshot-timestamp.yml
+++ b/.github/workflows/staging-snapshot-timestamp.yml
@@ -20,8 +20,8 @@ permissions: read-all
 on:
   workflow_dispatch:
     inputs:
-      repo:
-        description: 'The staging repository, e.g. ceremony/2022-10-18'
+      branch:
+        description: 'The branch where the staged repository is, e.g. ceremony/2022-10-18'
         required: true
         type: string
 
@@ -36,7 +36,7 @@ jobs:
     with:
       snapshot_key: 'gcpkms://projects/sigstore-root-signing/locations/global/keyRings/root/cryptoKeys/snapshot'
       timestamp_key: 'gcpkms://projects/sigstore-root-signing/locations/global/keyRings/root/cryptoKeys/timestamp'
-      repo: ${{ inputs.repo }}
+      branch: ${{ inputs.repo }}
       provider: 'projects/163070369698/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider'
       service_account: 'github-actions@sigstore-root-signing.iam.gserviceaccount.com'
       publish: false

--- a/config/targets-metadata.yml
+++ b/config/targets-metadata.yml
@@ -34,3 +34,4 @@ add:
     sigstore:
       usage: Unknown
       status: Active
+  trusted_root.json:

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -775,6 +775,12 @@ func TestProdTargetsConfig(t *testing.T) {
 	for name, tFiles := range targetFiles {
 		var v1, v2 interface{}
 		json.Unmarshal([]byte(targetsConfig.Add[name]), &v1)
+		if tFiles.Custom == nil {
+			if v2 != nil {
+				t.Errorf("no custom metadata found, expected: %s", v2)
+			}
+			continue
+		}
 		json.Unmarshal([]byte(*tFiles.Custom), &v2)
 		if !reflect.DeepEqual(v1, v2) {
 			t.Errorf("expected custom %s, got %s", targetsConfig.Add[name], *tFiles.Custom)


### PR DESCRIPTION
* This adds the trusted root targets file explicitly to the config to add to our next root signing event. I noticed it was missing from the targets during a test run.

Part of https://github.com/sigstore/root-signing/issues/616