### PR TITLE
ci: open PRs against branch

### DIFF
--- a/.github/workflows/initialize.yml
+++ b/.github/workflows/initialize.yml
@@ -123,6 +123,7 @@ jobs:
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
         with:
+          ref: ${{ inputs.branch }}
           fetch-depth: 0
       - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v2.1.0
         with:
@@ -158,6 +159,7 @@ jobs:
           title: Update Root and Targets to version ${{ env.VERSION }}
           body: Initializes a new root and targets to version ${{ env.VERSION }}
           branch: init-root-targets
+          base: ${{ inputs.branch }}
           signoff: true
           draft: ${{ inputs.draft }}
           reviewers: asraa,dlorenc,haydentherapper,joshuagl

--- a/pkg/repo/repo.go
+++ b/pkg/repo/repo.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -256,6 +257,7 @@ func GetSigningKeyIDsForRole(name string, store tuf.LocalStore) (
 			}
 			return nil, err
 		}
+		fmt.Fprintf(os.Stderr, "Adding previous root keys from root version %d\n", previousRoot.Version)
 		previousRootRole, ok := previousRoot.Roles[name]
 		if !ok {
 			return nil, fmt.Errorf("missing role %s on previous root", err)


### PR DESCRIPTION
I noticed the PRs were being created against `main`. 

* Ensure that PRs are created against the ceremony, by using `base` branch and also checking out the branch in the PR creation step.
* Adds a small Stderr debugging output to help with an issue I can't reproduce locally (despite checking out everything and matching state on the workflow): https://github.com/sigstore/root-signing/pull/627#issuecomment-1430314951

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->