### PR TITLE
ci: use fine grained PAT in initialize workflow to trigger presubmits

### DIFF
--- a/.github/workflows/cosign-test.yml
+++ b/.github/workflows/cosign-test.yml
@@ -18,11 +18,9 @@ name: Cosign tests
 on:
   workflow_dispatch:
   push:
-    branches: [main]
     paths:
       - 'repository/**'
   pull_request:
-    branches: [main]
 
 jobs:
   validate:

--- a/.github/workflows/initialize.yml
+++ b/.github/workflows/initialize.yml
@@ -150,7 +150,7 @@ jobs:
           git add ${REPO}
           git commit -s -m "Add staged repository metadata"
 
-      # Open pull request changes
+      # Open pull request changes. Use the fine-grained PAT in order to trigger presubmits.
       - name: create pull request
         uses: peter-evans/create-pull-request@2b011faafdcbc9ceb11414d64d0573f37c774b04 # v4.2.3
         with:
@@ -161,3 +161,4 @@ jobs:
           signoff: true
           draft: ${{ inputs.draft }}
           reviewers: asraa,dlorenc,haydentherapper,joshuagl
+          token: ${{ secrets.SIGSTORE_ROOT_SIGNING_FINE_GRAINED_PAT }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -8,7 +8,6 @@ on:
   schedule:
     - cron: '22 18 * * 6'
   push:
-    branches: ["main"]
 
 # Declare default permissions as none.
 permissions: {}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -8,6 +8,8 @@ on:
   schedule:
     - cron: '22 18 * * 6'
   push:
+    # Only default main branch is supported
+    branches: ["main"]
 
 # Declare default permissions as none.
 permissions: {}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,11 +17,9 @@ name: CI Test
 
 on:
   push:
-    branches: [main]
     paths-ignore:
       - 'ceremony/**'
   pull_request:
-    branches: [main]
     paths-ignore:
       - 'ceremony/**'
 

--- a/.github/workflows/tuf_client_tests.yml
+++ b/.github/workflows/tuf_client_tests.yml
@@ -18,11 +18,9 @@ name: TUF Client tests
 on:
   workflow_dispatch:
   push:
-    branches: [main]
     paths:
       - 'repository/**'
   pull_request:
-    branches: [main]
 
 jobs:
   client:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -17,12 +17,10 @@ name: CI Validate
 
 on:
   push:
-    branches: [main]
     paths:
       - 'ceremony/**'
       - 'repository/**'
   pull_request:
-    branches: [main]
 
 jobs:
   validate:


### PR DESCRIPTION
* Adds a token when creating the PR with the initialie GH workflow: this ensures that presubmits can actually trigger (otherwise a workflow cannot trigger another workflow)