### PR TITLE
fix: fix issue where InitCmd fails to initialize a new root with no changes

### DIFF
--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -932,3 +932,74 @@ func TestKeyPOP(t *testing.T) {
 		t.Fatal("verification should fail")
 	}
 }
+
+func TestRotateRootKeyTwiceAfter(t *testing.T) {
+	// This tests a corner case of key rotation. If a rotation occurs on
+	// v2, then we expect two signature placeholders for staging the v2 root.
+	// For the next v3, if there are no other root changes we should only
+	// expect one. Under the hood, this is testing that InitCmd always stages
+	// a new root before calculating placeholer signatures.
+	ctx := context.Background()
+	stack := newRepoTestStack(ctx, t)
+	stack.addTarget(t, "foo.txt", "abc", nil)
+	rootKeyRef1 := stack.genKey(t, true)
+	rootKeyRef2 := stack.genKey(t, true)
+
+	// Initialize succeeds
+	if err := app.InitCmd(ctx, stack.repoDir, 1,
+		stack.targetsConfig, stack.repoDir, stack.snapshotRef, stack.timestampRef); err != nil {
+		t.Fatal(err)
+	}
+
+	// Sign root & targets with key 1
+	rootSigner1 := stack.getSigner(t, rootKeyRef1)
+	if err := app.SignCmd(ctx, stack.repoDir, []string{"root", "targets"},
+		rootSigner1, false); err != nil {
+		t.Fatal(err)
+	}
+	pubKey1, err := keys.ConstructTufKey(ctx, rootSigner1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Sign snapshot and timestamp
+	stack.snapshot(t)
+	stack.timestamp(t)
+	stack.publish(t)
+
+	// Now remove the second key.
+	stack.removeHsmKey(t, rootKeyRef2)
+	// Create a new root.
+	if err := app.InitCmd(ctx, stack.repoDir, 1,
+		stack.targetsConfig, stack.repoDir, stack.snapshotRef, stack.timestampRef); err != nil {
+		t.Fatal(err)
+	}
+	// Sign root & targets
+	if err := app.SignCmd(ctx, stack.repoDir, []string{"root", "targets"}, rootSigner1,
+		false); err != nil {
+		t.Fatal(err)
+	}
+
+	// Sign snapshot and timestamp
+	stack.snapshot(t)
+	stack.timestamp(t)
+	stack.publish(t)
+
+	// Now, perform no new changes and init v3. Expect only ONE placeholder.
+	if err := app.InitCmd(ctx, stack.repoDir, 1,
+		stack.targetsConfig, stack.repoDir, stack.snapshotRef, stack.timestampRef); err != nil {
+		t.Fatal(err)
+	}
+
+	md := stack.getManifest(t, "root.json")
+	signed := &data.Signed{}
+	if err := json.Unmarshal(md, signed); err != nil {
+		t.Fatal(err)
+	}
+	if len(signed.Signatures) != 1 {
+		t.Fatalf("expected 1 signatures on root.json, got %d", len(signed.Signatures))
+	}
+	if !pubKey1.ContainsID(signed.Signatures[0].KeyID) {
+		t.Fatalf("missing key id for signer on root.json")
+	}
+}


### PR DESCRIPTION
This fixes a somewhat opaque issue that was very difficult to track down.

See https://github.com/sigstore/root-signing/pull/630 for an example.

I tested v6 root creation, and was surprised to see the v4 keyids being using as signature placeholders (I saw 10 of them). I could not reproduce this locally with the same binary build. 

It turns out this is what happened:
* Locally, I was using test snapshot/timestamp keys, which caused a root update and staged a new root.
* Retrieving the placeholder signatures for root (which include the previous root by TUF update chained signing), happens after any keys are updated.
* If NO keys are updated, then no v6 root is staged, so the placeholder signatures we compute are from the previous root (v4) and the current (v5).
* It is impossible to manually detect whether a metadata file is staged, so I fixed by ensuring that we stage the new metadata before we calculate the signing key IDs. 


<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->