### PR TITLE
docs: update verifier docs to remove ceremony/ folder reference

### DIFF
--- a/VERIFIER.md
+++ b/VERIFIER.md
@@ -1,18 +1,22 @@
+# Verifier Instructions
+
 At any point, a verifier can run a script to verify each incoming PR and verify the hashes of the targets files.
 
 Pre-requisites:
-- [ ] A local Git installation and a Go development setup with support for the Go version [here](https://github.com/sigstore/root-signing/blob/1d4462a5deaffbe3055b5e3fe3c53d1918594159/go.mod#L3)
+
+* [ ] A local Git installation and a Go development setup with support for the Go version [here](https://github.com/sigstore/root-signing/blob/1d4462a5deaffbe3055b5e3fe3c53d1918594159/go.mod#L3)
 * SSH authentication for GitHub (see [here](https://docs.github.com/en/authentication/connecting-to-github-with-ssh))
 
 0. **Verifiers** should fork [this](https://github.com/sigstore/root-signing) git repository by clicking the "fork" button on GitHub.
 
-1. To verify a PR, run the script with the pull request ID to verify, where `YOUR_GITHUB_USERNAME` is your GitHub username, and `REPO` is the date of the ceremony. Note that if the ceremony date differs from your current date, you will need to change that.
+1. To verify a PR, run the script with the pull request ID to verify, where `YOUR_GITHUB_USERNAME` is your GitHub username.
 
-```
-GITHUB_USER=${YOUR_GITHUB_USERNAME} REPO=$(pwd)/ceremony/$(date '+%Y-%m-%d') ./scripts/verify.sh ${PULL_REQUEST_ID}
+```bash
+GITHUB_USER=${YOUR_GITHUB_USERNAME} ./scripts/verify.sh ${PULL_REQUEST_ID}
 ```
 
 This will download the Yubico root CA. For each key added, it will verify:
+
 * That the hardware key is authentic and came from the manufacturer (using the device cert)
 * That the signing key was generated on the device (using the key attestation)
 * That the directory where they keys were added match the serial number from the cert (preventing a keyholder from using their key multiple times)
@@ -21,8 +25,6 @@ If there is any repository data added in the PR, it will also check signatures i
 
 2. Other verifications:
 
-  * Verify the targets signed and their SHAs. You may choose to retrieve an independent local copy of the targets (Fulcio Root CA certificate, SigStore signing key, Rekor public key, CTFE key) and verify that the SHA-512 matches the sha in `targets.json`.
+* Verify the targets signed and their SHAs. You may choose to retrieve an independent local copy of the targets (Fulcio Root CA certificate, SigStore signing key, Rekor public key, CTFE key) and verify that the SHA-512 matches the sha in `targets.json`.
 
-  * Manual hardware key verification using OpenSSL: the verification script will also output commands for OpenSSL certificate text output and verification for each key it sees. You may choose to run those manually. It will verify the key certificate using the device certificate intermediate and the Yubikey Root CA. It will also extract the public key from the key certificate to compare with the public key in the repository.
-
-
+* Manual hardware key verification using OpenSSL: the verification script will also output commands for OpenSSL certificate text output and verification for each key it sees. You may choose to run those manually. It will verify the key certificate using the device certificate intermediate and the Yubikey Root CA. It will also extract the public key from the key certificate to compare with the public key in the repository.

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -23,7 +23,7 @@ if [ -z "$GITHUB_USER" ]; then
     exit 1
 fi
 if [ -z "$REPO" ]; then
-    REPO=$(pwd)/ceremony/$(date '+%Y-%m-%d')
+    REPO=$(pwd)/repository
     echo "Using default REPO $REPO"
 fi
 


### PR DESCRIPTION
This updates the `VERIFIER.md` with some MD format nits and removes the references to `ceremony/*` folders. Instead, the `REPO` is the top-level repository where changes are staged. They do not need to be aware of the branches because the PR fetch already retrieves that state. 

For example, you can verify a PR against a new branch
```
GITHUB_USER=asraa  ./scripts/verify.sh 634
```

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->