### PR TITLE
docs: update signer docs to remove ceremony references

### DIFF
--- a/playbooks/keyholders/EXISTING_SIGNER.md
+++ b/playbooks/keyholders/EXISTING_SIGNER.md
@@ -17,48 +17,49 @@ Complete the following steps in order:
 ### Pre-requisites
 
 Ensure you have the following:
+
 - [ ] A local Git installation and a Go development setup with support for the Go version [here](https://github.com/sigstore/root-signing/blob/1d4462a5deaffbe3055b5e3fe3c53d1918594159/go.mod#L3)
 - [ ] SSH authentication for GitHub (see [here](https://docs.github.com/en/authentication/connecting-to-github-with-ssh))
 - [ ] A USB port connection for your hardware key (beware of using a remote connection; the keyholder should not assume that magic occurs during an SSH session)
 - [ ] A fresh environment. In particular, ensure that environment variables like `LOCAL`, `GITHUB_USER`, and `BRANCH` are unset before you begin.
 - [ ] A fork of the [root-signing](https://github.com/sigstore/root-signing) repository. Click the "fork" button on GitHub and clone the forked repository.
 
-### Setup 
+### Setup
 
 - [ ] Test binary build: Set your `${GITHUB_USER}` with your GitHub username and execute the script:
+
 ```bash
 export GITHUB_USER=${GITHUB_USER}
 export LOCAL=1
 ./scripts/step-0.sh
 ```
+
 This will setup your clone and build the TUF binary to use for metadata generation. This will also disable PR creations after each step and allow you to test changes locally.
- 
+
 ### Metadata Creation
 
 - [ ] Create new unsigned metadata with the following:
+
 ```bash
 export TEST_KEY=./tests/test_data/cosign.key
 export TIMESTAMP_KEY=$TEST_KEY
 export SNAPSHOT_KEY=$TEST_KEY
-export REKOR_KEY=$TEST_KEY
-export STAGING_KEY=$TEST_KEY
-export REVOCATION_KEY=$TEST_KEY
-export PREV_REPO=$(pwd)/repository
 ./scripts/step-1.5.sh
 ```
 
-- [ ] **CONFIRM** that you created a new directory under `ceremony/$DATE/staged/` and it is populated with a `root.json` and `targets.json` along with other delegation metadata files.
+- [ ] **CONFIRM** that you created a new directory under `repository/staged/` and it is populated with a `root.json` and `targets.json` along with a `targets` subfolder.
 
 ### Signing
 
-- [ ] Sign the root and targets metadata with the following command. 
-```
+- [ ] Sign the root and targets metadata with the following command.
+
+```bash
 ./scripts/step-2.sh
 ```
 
 You will be prompted to insert your hardware key. Insert it and continue. Then, it will prompt you for your PIN twice to sign `root.json` and `targets.json`. This will populate a signature for your key id in the `signatures` section for these two top-level roles.
 
-```
+```bash
 {
   "signatures": [
     {
@@ -73,8 +74,8 @@ You will be prompted to insert your hardware key. Insert it and continue. Then, 
 It will then prompt you to remove the hardware token. During the actual ceremony, it will push a PR to the root-signing repository.
 
 - [ ] **CONFIRM**: Run the following and make sure that you see 1 valid signature for root and targets.
+
 ```bash
-export REPO=$(pwd)/ceremony/$(date '+%Y-%m-%d')
 ./scripts/verify.sh
 ```
 
@@ -85,25 +86,29 @@ During the actual ceremony, you will need to renew the [setup](#setup-1) and per
 ### Pre-requisites
 
 Ensure you have the following:
+
 - [ ] A local Git installation and a Go development setup with support for the Go version [here](https://github.com/sigstore/root-signing/blob/1d4462a5deaffbe3055b5e3fe3c53d1918594159/go.mod#L3)
 - [ ] SSH authentication for GitHub (see [here](https://docs.github.com/en/authentication/connecting-to-github-with-ssh))
 - [ ] A USB port connection for your hardware key (beware of using a remote connection; the keyholder should not assume that magic occurs during an SSH session)
 - [ ] A fresh environment. In particular, ensure that environment variables like `LOCAL`, `GITHUB_USER`, and `BRANCH` are unset before you begin.
 
-### Setup 
+### Setup
 
 - [ ] Binary build: Set your `${GITHUB_USER}` with your GitHub username and execute the script:
+
 ```bash
 export GITHUB_USER=${GITHUB_USER}
 ./scripts/step-0.sh
 ```
+
 This will setup your clone and build the TUF binary to use for metadata generation.
 
 ### Signing
 
-When prompted in the Slack channel, begin signing root and targets metadata. If the ceremony started on a prior date (or the date in your timezone does not match the date in the orchestrator's timezone), you should add a repository reference by setting `REPO`. Otherwise, for same-day signing, you may omit to default to the current date. Run:
-```
-REPO=$(pwd)/ceremony/<START_DATE> ./scripts/step-2.sh
+When prompted in the Slack channel, begin signing root and targets metadata. You **MUST** set the `BRANCH` variable to the desired ceremony date (if the ceremony was scheduled to start on a prior date or the date in your timeone does not match the orchestrator's timezome, it may differ from the current date). Run:
+
+```bash
+BRANCH=ceremony/<START_DATE> ./scripts/step-2.sh
 ```
 
-Again, this will populate a signature for your key id in the `signatures` section for these two top-level roles and push a PR that will be verified and merged.
+Again, this will populate a signature for your key id in the `signatures` section for these two top-level roles and push a PR against the upstream branch that will be verified and merged.

--- a/playbooks/keyholders/NEW_SIGNER.md
+++ b/playbooks/keyholders/NEW_SIGNER.md
@@ -16,47 +16,56 @@ Complete the following steps in order:
 ### Pre-requisites
 
 Ensure you have the following:
+
 - [ ] A local Git installation and a Go development setup with support for the Go version [here](https://github.com/sigstore/root-signing/blob/1d4462a5deaffbe3055b5e3fe3c53d1918594159/go.mod#L3)
 - [ ] SSH authentication for GitHub (see [here](https://docs.github.com/en/authentication/connecting-to-github-with-ssh))
 - [ ] A USB port connection for your hardware key (beware of using a remote connection; the keyholder should not assume that magic occurs during an SSH session)
 - [ ] A fresh environment. In particular, ensure that environment variables like `LOCAL`, `GITHUB_USER`, and `BRANCH` are unset before you begin.
 - [ ] A fork of the [root-signing](https://github.com/sigstore/root-signing) repository. Click the "fork" button on GitHub and clone the forked repository.
 
-### Setup 
+### Setup
 
 - [ ] Test binary build: Set your `${GITHUB_USER}` with your GitHub username and execute the script:
+
 ```bash
 export GITHUB_USER=${GITHUB_USER}
 export LOCAL=1
 ./scripts/step-0.sh
 ```
+
 This will setup your clone and build the TUF binary to use for metadata generation. This will also disable PR creations after each step and allow you to test changes locally.
- 
+
 ### Registration
 
-Do not use an existing key that is already in-use and you need to continue using -- this process will wipe the key! 
+Do not use an existing key that is already in-use and you need to continue using -- this process will wipe the key!
 
-- [ ] Add your key with the following.
-```
+- [ ] Add your key with the following. Run:
+
+```bash
 ./scripts/step-1.sh
 ```
 
 This step will reset your hardware key and will set a PIN. Choose a PIN between 6 and 8 characters that you will remember for signing in later steps.
 
-This will output three files (a public key, device certificate, and hardware certificate) in a directory named with your serial number `ceremony/YYYY-MM-DD/keys/${SERIAL_NUM}`. During the actual ceremony, it will push a PR to the root-signing repository.
+This will output three files (a public key, device certificate, and hardware certificate) in a directory named with your serial number `repository/keys/${SERIAL_NUM}`. During the actual ceremony, it will push a PR against `BRANCH` to the root-signing repository.
 
-- [ ] **CONFIRM** that you created a new directory under `ceremony/$DATE/keys/` with a new serial numbered `XXXXXX` directory. Run the following and confirm that there is some output with `VERIFIED KEY WITH SERIAL NUMBER XXXXXX`.
+- [ ] **CONFIRM** that you created a new directory under `repository/keys/` with a new serial numbered `XXXXXX` directory. Run the following and confirm that there is some output with `VERIFIED KEY WITH SERIAL NUMBER XXXXXX`.
+
 ```bash
 ./scripts/verify.sh
 ```
 
 **Troubleshooting**
+
 1. You may need to install `libpcslite` to support hardware tokens. See [`go-piv`'s installation instructions for your platform.](https://github.com/go-piv/piv-go#installation).
 2. If you hit the error
+
 ```
 error: connecting to pscs: the Smart card resource manager is not running
 ```
+
 then run the following to start the pcsc daemon (note: this may require root access):
+
 ```
 systemctl start pcscd.service
 systemctl enable pcscd.service
@@ -65,29 +74,27 @@ systemctl enable pcscd.service
 ### Metadata Creation
 
 - [ ] Create new unsigned metadata with the following:
+
 ```bash
 export TEST_KEY=./tests/test_data/cosign.key
 export TIMESTAMP_KEY=$TEST_KEY
 export SNAPSHOT_KEY=$TEST_KEY
-export REKOR_KEY=$TEST_KEY
-export STAGING_KEY=$TEST_KEY
-export REVOCATION_KEY=$TEST_KEY
-export PREV_REPO=$(pwd)/repository
 ./scripts/step-1.5.sh
 ```
 
-- [ ] **CONFIRM** that you created a new directory under `ceremony/$DATE/staged/` and it is populated with a `root.json` and `targets.json` along with other delegation metadata files.
+- [ ] **CONFIRM** that you created a new directory under `repository/staged/` and it is populated with a `root.json` and `targets.json` along with a `targets` subfolder.
 
 ### Signing
 
-- [ ] Sign the root and targets metadata with the following command. 
-```
+- [ ] Sign the root and targets metadata with the following command.
+
+```bash
 ./scripts/step-2.sh
 ```
 
 You will be prompted to insert your hardware key. Insert it and continue. Then, it will prompt you for your PIN twice to sign `root.json` and `targets.json`. This will populate a signature for your key id in the `signatures` section for these two top-level roles.
 
-```
+```json
 {
   "signatures": [
     {
@@ -102,8 +109,8 @@ You will be prompted to insert your hardware key. Insert it and continue. Then, 
 It will then prompt you to remove the hardware token. During the actual ceremony, it will push a PR to the root-signing repository.
 
 - [ ] **CONFIRM**: Run the following and make sure that you see 1 valid signature for root and targets.
+
 ```bash
-export REPO=$(pwd)/ceremony/$(date '+%Y-%m-%d')
 ./scripts/verify.sh
 ```
 
@@ -114,6 +121,7 @@ During the actual ceremony, you will need to renew the [setup](#setup-1) and per
 ### Pre-requisites
 
 Ensure you have the following:
+
 - [ ] A local Git installation and a Go development setup with support for the Go version [here](https://github.com/sigstore/root-signing/blob/1d4462a5deaffbe3055b5e3fe3c53d1918594159/go.mod#L3)
 - [ ] SSH authentication for GitHub (see [here](https://docs.github.com/en/authentication/connecting-to-github-with-ssh))
 - [ ] A USB port connection for your hardware key (beware of using a remote connection; the keyholder should not assume that magic occurs during an SSH session)
@@ -122,26 +130,30 @@ Ensure you have the following:
 ### Setup 
 
 - [ ] Binary build: Set your `${GITHUB_USER}` with your GitHub username and execute the script:
+
 ```bash
 export GITHUB_USER=${GITHUB_USER}
 ./scripts/step-0.sh
 ```
+
 This will setup your clone and build the TUF binary to use for metadata generation.
 
 ### Registration
 
-The first step of the ceremony will require new keyholders to register their keys. Wait for a Slack message asking you to start Registration, and run:
-```
-./scripts/step-1.sh
+The first step of the ceremony will require new keyholders to register their keys. Wait for a Slack message asking you to start Registration. You **MUST** set the `BRANCH` variable to the desired ceremony date (if the ceremony was scheduled to start on a prior date or the date in your timeone does not match the orchestrator's timezome, it may differ from the current date). Run:
+
+```bash
+BRANCH=ceremony/<START_DATE> ./scripts/step-1.sh
 ```
 
-Like testing, this will create a new directory under `ceremony/$DATE/keys/` with a new serial numbered `XXXXXX` directory. It will also push a PR that the community will verify and merge.
+Like testing, this will create a new directory under `repository/keys/` with a new serial numbered `XXXXXX` directory. It will also push a PR against the `BRANCH` that the community will verify and merge.
 
 ### Signing
 
-When prompted in the Slack channel, begin signing root and targets metadata. If the ceremony started on a prior date (or the date in your timezone does not match the date in the orchestrator's timezone), you should add a repository reference by setting `REPO`. Otherwise, for same-day signing, you may omit to default to the current date. Run:
-```
-REPO=$(pwd)/ceremony/<START_DATE> ./scripts/step-2.sh
+When prompted in the Slack channel, begin signing root and targets metadata. You **MUST** set the `BRANCH` variable to the desired ceremony date (if the ceremony was scheduled to start on a prior date or the date in your timeone does not match the orchestrator's timezome, it may differ from the current date). Run:
+
+```bash
+BRANCH=ceremony/<START_DATE> ./scripts/step-2.sh
 ```
 
 Again, this will populate a signature for your key id in the `signatures` section for these two top-level roles and push a PR that will be verified and merged.


### PR DESCRIPTION
This PR updates the signer docs to remove ceremony `REPO` references and replace with ceremony `BRANCH` references.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->