### PR TITLE
feat: move snapshot, timestamp, publish to branches

### DIFF
--- a/.github/workflows/reuseable-snapshot-timestamp.yml
+++ b/.github/workflows/reuseable-snapshot-timestamp.yml
@@ -34,10 +34,14 @@ on:
         description: 'Sets the timestamping key reference'
         required: true
         type: string
+      branch:
+        description: 'The branch where the staged repository is, e.g. ceremony/2022-10-18'
+        required: true
+        type: string
       repo:
-        description: 'Sets the repository to perform the operation on: expects relative path to GitHub repository, for example: ceremony/2022-10-03'
+        description: 'Sets the repository to perform the operation on: expects relative path to GitHub repository, for example: repository'
         required: false
-        default: repository/
+        default: repository
         type: string
       provider:
         description: 'Sets the workflow identity provider'
@@ -73,6 +77,7 @@ jobs:
           echo "REPO=$(pwd)/${{ inputs.repo }}" >> $GITHUB_ENV
           echo "SNAPSHOT_KEY=${{ inputs.snapshot_key }}" >> $GITHUB_ENV
           echo "TIMESTAMP_KEY=${{ inputs.timestamp_key }}" >> $GITHUB_ENV
+          echo "BRANCH=${{ inputs.branch }}" >> $GITHUB_ENV
           # Note: we set LOCAL=1 because we manually push the changes in the next job.
           echo "LOCAL=1" >> $GITHUB_ENV
       - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0

--- a/.github/workflows/stable-snapshot-timestamp.yml
+++ b/.github/workflows/stable-snapshot-timestamp.yml
@@ -44,6 +44,7 @@ jobs:
       snapshot_key: 'gcpkms://projects/sigstore-root-signing/locations/global/keyRings/root/cryptoKeys/snapshot'
       timestamp_key: 'gcpkms://projects/sigstore-root-signing/locations/global/keyRings/root/cryptoKeys/timestamp'
       repo: 'repository/'
+      branch: main
       provider: 'projects/163070369698/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider'
       service_account: 'github-actions@sigstore-root-signing.iam.gserviceaccount.com'
     secrets:

--- a/.github/workflows/staging-snapshot-timestamp.yml
+++ b/.github/workflows/staging-snapshot-timestamp.yml
@@ -36,7 +36,7 @@ jobs:
     with:
       snapshot_key: 'gcpkms://projects/sigstore-root-signing/locations/global/keyRings/root/cryptoKeys/snapshot'
       timestamp_key: 'gcpkms://projects/sigstore-root-signing/locations/global/keyRings/root/cryptoKeys/timestamp'
-      branch: ${{ inputs.repo }}
+      branch: ${{ inputs.branch }}
       provider: 'projects/163070369698/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider'
       service_account: 'github-actions@sigstore-root-signing.iam.gserviceaccount.com'
       publish: false

--- a/playbooks/ORCHESTRATION.md
+++ b/playbooks/ORCHESTRATION.md
@@ -139,14 +139,13 @@ Verify their PRs with the PR number as the argument to the script:
 
 You should expect 1 signature added to root and targets on each PR.
 
-After each of the root keyholder PRs are merged, run verification at main:
+After each of the root keyholder PRs are merged, run verification at the head of the ceremony branch:
 
 ```bash
 ./scripts/verify.sh
 ```
 
 and verify that the root and targets are fully signed.
-
 
 <!--  
 TODO(https://github.com/sigstore/root-signing/issues/398):
@@ -169,14 +168,12 @@ This will create a PR signing the delegations. Verify the PR with the PR number 
 and check that the delegation was successfully signed.
  -->
 
-
 ## Step 3: Snapshotting and Timestamping
 
-Next, the metadata will need to be snapshotted and timestamped. Run
+Next, the metadata will need to be snapshotted and timestamped. Invoke the staging snapshot and timestamp GitHub workflow [staging-snapshot-timestamp.yml](../.github/workflows/staging-snapshot-timestamp.yml) with the following parameters:
 
-```bash
-./scripts/step-3.sh
-```
+* `branch`: The branch you created for the ceremony, like `ceremony/YYYY-MM-DD`.
+* `repo`: The repository folder to trigger this action against, likely the default `repository/` suffices.
 
 This will create a PR signing the snapshot and timestamp files. Verify the expirations and the signatures:
 
@@ -184,19 +181,7 @@ This will create a PR signing the snapshot and timestamp files. Verify the expir
 ./scripts/verify.sh $PR
 ```
 
-## Step 4: Publishing
-
-This final step will commit the TUF repository metadata and move it to the top-level folder `repository/repository/`.
-
-```bash
-./scripts/step-4.sh
-```
-
-This will create a PR moving the files. Verify that the TUF client can update to the new metadata with:
-
-```bash
-./scripts/verify.sh $PR
-```
+Note: You cannot test this step locally against the current staged repository, since the snapshot and timestamp keys are only given permissions to the GitHub Workflows. However, under the hood, the workflow is running `./scripts/step-3.sh` and `./scripts/step-4.sh`. If you initialize a ceremony with local testing keys, this action will work.
 
 ## Post-ceremony Steps
 

--- a/scripts/step-4.sh
+++ b/scripts/step-4.sh
@@ -36,10 +36,5 @@ checkout_branch
 
 # Sign the root and targets
 ./tuf publish -repository "$REPO"
-# Clear and copy into the repository/
-TEMP_REPO="$(mktemp -d)"
-cp -r "$REPO"/* "$TEMP_REPO"
-rm -r repository/*
-cp -r "$TEMP_REPO"/* repository/
 
 commit_and_push_changes publish


### PR DESCRIPTION
This PR moves the final snapshot, timestamp and publish workflow to the new flow of working on ceremony branches rather than folders.

* Updates docs for the orchestrator
* Adds a `branch` option to the reusable snapshot & timestamp workflow. The one that works at main (the automated one) uses `main`. The one for staging (a workflow dispatch) requires the `branch` name.
* Updates `./scripts/step-4.sh` - we no longer need the temporary move, since we operate on the same repository folder. (However, I know that it also worked for the same repository folder, since that's what the automated job performs on, but doing this for simplifying code. @kommendorkapten @haydentherapper this is the only thing I expect that might go wrong during testing).

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->