### PR TITLE
Skip the usage of ceremony directory and default to ./repository

### DIFF
--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -41,7 +41,7 @@ checkout_branch() {
     git checkout "${BRANCH}"
     if [ -n "$LOCAL" ]; then
         echo "Working on local changes. There may be uncommitted changes, so skipping upstream pull..."
-    else 
+    else
         git fetch upstream
         git pull upstream "${BRANCH}"
     fi


### PR DESCRIPTION
Signed-off-by: Fredrik Skogman <kommendorkapten@github.com>

#### Summary
Remove the old `ceremony/<date>` directory and default to `./repository` directory. 

#### Release Note
N/A

#### Documentation
N/A