### PR TITLE
update test ctlog validFor period in trusted root

### DIFF
--- a/targets/trusted_root.json
+++ b/targets/trusted_root.json
@@ -64,8 +64,8 @@
         "rawBytes": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEbfwR+RJudXscgRBRpKX1XFDy3PyudDxz/SfnRi1fT8ekpfBd2O1uoz7jr3Z8nKzxA69EUQ+eFCFI3zeubPWU7w==",
         "keyDetails": "PKIX_ECDSA_P256_SHA_256",
         "validFor": {
-          "start": "2021-03-07T03:20:29.000Z",
-          "end": "2022-01-01T00:00:00.000Z"
+          "start": "2021-03-14T00:00:00.000Z",
+          "end": "2022-10-31T23:59:59.999Z"
         }
       },
       "logId": {


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->
Per #616 

#### Summary
Updating the `trusted_root.json` target with the correct valid-for range on the "https://ctfe.sigstore.dev/test" ctlog entry.

In an effort to get better start/end dates, I examined the first and last entries on the "test" ctlog and looked at the corresponding timestamps:

```bash
curl "https://ctfe.sigstore.dev/test/ct/v1/get-entries?start=0&end=0"
curl "https://ctfe.sigstore.dev/test/ct/v1/get-entries?start=3533286&end=3533286"
```

I found the first and last timestamps to be "2021-03-14T16:27:21.940Z" and "2022-10-31T19:29:48.033Z" 

When setting the valid-for range for the corresponding ctlog key, I rounded that first timestamp down to the beginning of the day and rounded the last timestamp up to the end of the day.

(@haydentherapper am I on the right track here?)