### PR TITLE
Use fine-grained PAT

### DIFF
--- a/.github/workflows/reuseable-snapshot-timestamp.yml
+++ b/.github/workflows/reuseable-snapshot-timestamp.yml
@@ -163,7 +163,7 @@ jobs:
           branch: update-snapshot-timestamp
           signoff: true
           reviewers: asraa,dlorenc,haydentherapper,joshuagl
-          token: ${{ secrets.token }}
+          token: ${{ secrets.SIGSTORE_ROOT_SIGNING_FINE_GRAINED_PAT }}
 
   if-push-failed:
     runs-on: ubuntu-latest


### PR DESCRIPTION
#### Summary
When creating a PR with the snapshot and timestamped data, use the fine grained PAT, I believe that the coarse grained PAT is not available any more, see: https://github.com/sigstore/root-signing/actions/runs/4242884023/jobs/7374980521#step:4:14

#### Release Note
N/A

#### Documentation
N/A