### PR TITLE
Fetch upstream before changing branch

### DIFF
--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -38,11 +38,11 @@ checkout_branch() {
         BRANCH=main
     fi
     echo "Working from branch $BRANCH"
-    git checkout "${BRANCH}"
     if [ -n "$LOCAL" ]; then
         echo "Working on local changes. There may be uncommitted changes, so skipping upstream pull..."
-    else 
+    else
         git fetch upstream
+        git checkout "${BRANCH}"
         git pull upstream "${BRANCH}"
     fi
     git rev-parse HEAD


### PR DESCRIPTION
#### Summary
Fetch upstream before checkout of the signing branch. Currently `step-0.sh` is not working due to this.

#### Release Note
N/A

#### Documentation
N/A