### PR TITLE
When cloning the repo, use the provied branch.

### DIFF
--- a/.github/workflows/reuseable-snapshot-timestamp.yml
+++ b/.github/workflows/reuseable-snapshot-timestamp.yml
@@ -71,6 +71,7 @@ jobs:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
         with:
           fetch-depth: 0
+          ref: ${{ inputs.branch }}
       - name: setup
         run: |
           echo "GITHUB_USER=${{ github.actor }}" >> $GITHUB_ENV


### PR DESCRIPTION
Closes https://github.com/sigstore/root-signing/issues/661

#### Summary
When running the snapshot and timestamp job, the provided branch is not used, this PR changes that.

#### Release Note
N/A

#### Documentation
N/A