### PR TITLE
Use the correct base for the PR.

### DIFF
--- a/.github/workflows/reuseable-snapshot-timestamp.yml
+++ b/.github/workflows/reuseable-snapshot-timestamp.yml
@@ -165,6 +165,7 @@ jobs:
           signoff: true
           reviewers: asraa,dlorenc,haydentherapper,joshuagl
           token: ${{ secrets.token || secrets.GITHUB_TOKEN }}
+          base: ${{ inputs.branch }}
 
   if-push-failed:
     runs-on: ubuntu-latest


### PR DESCRIPTION
#### Summary
When reading the documentation for the action that creates the PR I read:
```
Defaults to the branch checked out in the workflow.
```

And interpreted that as the branch checked out by the action, not the branch that runs the action, so didn't set the value, but apparently it's needed. This PR does that.

#### Release Note


#### Documentation
