### PR TITLE
feat: add a feature to verify the head of a branch

### DIFF
--- a/VERIFIER.md
+++ b/VERIFIER.md
@@ -23,7 +23,13 @@ This will download the Yubico root CA. For each key added, it will verify:
 
 If there is any repository data added in the PR, it will also check signatures in each top-level role.
 
-2. Other verifications:
+2. To verify the state of a ceremony branch, add the environment variable `BRANCH` to indicate the ceremony branch.
+
+```bash
+GITHUB_USER=${YOUR_GITHUB_USERNAME} BRANCH=${CEREMONY_BRANCH} ./scripts/verify.sh
+```
+
+3. Other verifications:
 
 * Verify the targets signed and their SHAs. You may choose to retrieve an independent local copy of the targets (Fulcio Root CA certificate, SigStore signing key, Rekor public key, CTFE key) and verify that the SHA-512 matches the sha in `targets.json`.
 

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -18,26 +18,24 @@
 set -o errexit
 set -o xtrace
 
-if [ -z "$GITHUB_USER" ]; then
-    echo "Set GITHUB_USER"
-    exit 1
-fi
-if [ -z "$REPO" ]; then
-    REPO=$(pwd)/repository
-    echo "Using default REPO $REPO"
-fi
+# shellcheck source=./scripts/utils.sh
+source "./scripts/utils.sh"
 
-# Dump the git state
-git checkout main
-git status
-git remote -v
+# Check that a github user is set.
+check_user
+
+# Set REPO
+set_repository
+
+# Dump the git state and clean-up
+print_git_state
+clean_state
 
 # Setup forks
-git remote rm upstream || true
-git remote add upstream git@github.com:sigstore/root-signing.git
-git remote rm origin || true
-git remote add origin git@github.com:"$GITHUB_USER"/root-signing.git
-git remote -v
+setup_forks
+
+# Checkout branch
+checkout_branch
 
 # build the verification binary
 go build -o verify ./cmd/verify


### PR DESCRIPTION
This allows someone to verify the state of a ceremony at its head. Let's say, when the signing PRs have been merged. 

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->