### PR TITLE
Derive the repo from the context instead of hard code it

### DIFF
--- a/.github/workflows/delegation-pop-verify.yml
+++ b/.github/workflows/delegation-pop-verify.yml
@@ -32,7 +32,6 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.SIGSTORE_REVIEW_BOT_FINE_GRAINED_PAT }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
-      ISSUE_REPOSITORY: sigstore/root-signing
     steps:
       - name: Setup go
         uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0

--- a/.github/workflows/scripts/dpop-wrapper.sh
+++ b/.github/workflows/scripts/dpop-wrapper.sh
@@ -29,5 +29,4 @@ OUTPUT=$(mktemp)
 
 # If we made it here, signature verification was successful.
 # Add a comment with the output
-GH_TOKEN=${GITHUB_TOKEN} gh -R "${ISSUE_REPOSITORY}" \
-        pr comment "${PR_NUMBER}" -F "${OUTPUT}"
+GH_TOKEN=${GITHUB_TOKEN} gh pr comment "${PR_NUMBER}" -F "${OUTPUT}"


### PR DESCRIPTION

#### Summary
The repo is hardcoded in the workflow file, which makes it harder to test in another repo. When using `gh` CLI, it defaults to the current repo so this override should not be required. 

#### Release Note
n/a

#### Documentation
n/a