### PR TITLE
Updated dpop-verify to be able to run locally.

### DIFF
--- a/scripts/dpop-verify.sh
+++ b/scripts/dpop-verify.sh
@@ -23,6 +23,7 @@ MERGE_BASE=origin/main
 
 if [ $# -gt 1 ]; then
     # params are: PR DELEGATION_NAME
+    # Intended for users locally verifying a PR that contains a POP
     PR=$1
     DELEGATION=$2
 

--- a/scripts/dpop-verify.sh
+++ b/scripts/dpop-verify.sh
@@ -36,9 +36,9 @@ if [ $# -gt 1 ]; then
     clean_state
     setup_forks
 
-    echo "Pull Request: $1"
+    echo "Pull Request: ${PR}"
     git branch -D VERIFY || true
-    git fetch upstream pull/"$1"/head:VERIFY
+    git fetch upstream pull/"${PR}"/head:VERIFY
     git fetch origin
     git checkout VERIFY
 

--- a/scripts/dpop-verify.sh
+++ b/scripts/dpop-verify.sh
@@ -19,10 +19,36 @@ set -o errexit
 set -o xtrace
 set -u
 
+MERGE_BASE=origin/main
+
+if [ $# -gt 1 ]; then
+    # params are: PR DELEGATION NAME
+    PR=$1
+    DELEGATION=$2
+
+    REPO=${REPO:-./repository}
+    LOCAL=${LOCAL:-}
+    . "./scripts/utils.sh"
+    # Prepare the environment
+    check_user
+    set_repository
+    print_git_state
+    clean_state
+    setup_forks
+
+    echo "Pull Request: $1"
+    git branch -D VERIFY || true
+    git fetch upstream pull/"$1"/head:VERIFY
+    git fetch origin
+    git checkout VERIFY
+
+else
+    DELEGATION=$1
+    REPO=./repository
+fi
+
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
-FORK_POINT=$(git merge-base --fork-point origin/main "${BRANCH}")
-REPO=./repository
-DELEGATION=$1
+FORK_POINT=$(git merge-base --fork-point ${MERGE_BASE} "${BRANCH}")
 SIG_FILE="${REPO}"/staged/"${FORK_POINT}".sig
 
 if [ ! -f "${SIG_FILE}" ]; then

--- a/scripts/dpop-verify.sh
+++ b/scripts/dpop-verify.sh
@@ -22,7 +22,7 @@ set -u
 MERGE_BASE=origin/main
 
 if [ $# -gt 1 ]; then
-    # params are: PR DELEGATION NAME
+    # params are: PR DELEGATION_NAME
     PR=$1
     DELEGATION=$2
 

--- a/scripts/dpop-verify.sh
+++ b/scripts/dpop-verify.sh
@@ -43,6 +43,9 @@ if [ $# -gt 1 ]; then
     git checkout VERIFY
 
 else
+  # params are: PR
+  # Intended for usage inside a GitHub workflow context where the 
+  # pull request has already been checked out.
     DELEGATION=$1
     REPO=./repository
 fi


### PR DESCRIPTION
For now the script expects the name of the delegation as a parameter. For manual verification I think that providing this explicitly makes sense.

#### Summary
Closes https://github.com/sigstore/root-signing/issues/708

Run POP verification for a delegation locally, but checking out an open PR and verify the content.

#### Release Note
n/a

#### Documentation
n/a