### PR TITLE
fix: fix merge conflict during ceremony week by blocking cron snapshot/timestamp

### DIFF
--- a/.github/workflows/stable-snapshot-timestamp.yml
+++ b/.github/workflows/stable-snapshot-timestamp.yml
@@ -30,10 +30,47 @@ on:
     paths:
       - 'repository/staged/root.json'
   workflow_dispatch:
+    inputs:
+      dry_run:
+        type: boolean
+        default: false
+        description: Does not trigger job, but checks on whether the job should run.
 
 jobs:
+  check:
+    # This job checks whether snapshot/timestamp should run.
+    runs-on: ubuntu-latest
+    outputs:
+      ceremony_wip: ${{ steps.check.outputs.wip }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Determine whether to run a snapshot/timestamp
+        id: check
+        run: |
+          BRANCHES=$(git branch  | grep ceremony/)
+          echo "${BRANCHES}"
+          # Check whether a ceremony was initiated within a week of the current date.
+          echo "wip=false" >> $GITHUB_OUTPUT
+          ceremony-re="^ceremony/[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+          for branch in "${BRANCHES}"
+          do
+            if [[ "$branch" ~= "$ceremony-re" ]]; then
+              echo "found ceremony branch $branch"
+              branch_date=$(echo "$branch" | cut -d '/' -f2)
+              days_diff=$(( (`date -d $branch_date +%s` - `date -d "00:00" +%s`) / (24*3600) ))
+              if [[ "$days_diff" -lt 7 ]]; then
+                # Detected ceremony within 7 days of current date
+                echo "detected ceremony branch $branch within 7 days, stopping automated cron"
+                echo "wip=true" >> $GITHUB_OUTPUT
+              fi
+            fi
+          done
+
   run_snapshot_timestamp_publish:
-    if: (github.event_name == 'schedule' && github.repository == 'sigstore/root-signing') || (github.event_name != 'schedule')  # Don't run workflow in forks on cron
+    needs: check
+    if: (github.event_name == 'schedule' && github.repository == 'sigstore/root-signing' && needs.check.outputs.ceremony_wip == 'true') || (github.event_name != 'schedule' && inputs.dry_run == 'false')  # Don't run workflow in forks on cron
     permissions:
       id-token: 'write'
       issues: 'write'

--- a/.github/workflows/stable-snapshot-timestamp.yml
+++ b/.github/workflows/stable-snapshot-timestamp.yml
@@ -70,7 +70,7 @@ jobs:
 
   run_snapshot_timestamp_publish:
     needs: check
-    if: (github.event_name == 'schedule' && github.repository == 'sigstore/root-signing' && needs.check.outputs.ceremony_wip == 'true') || (github.event_name != 'schedule' && inputs.dry_run == 'false')  # Don't run workflow in forks on cron
+    if: (github.event_name == 'schedule' && github.repository == 'sigstore/root-signing' && needs.check.outputs.ceremony_wip == 'false') || (github.event_name != 'schedule' && inputs.dry_run == 'false')  # Don't run workflow in forks on cron
     permissions:
       id-token: 'write'
       issues: 'write'

--- a/playbooks/ORCHESTRATION.md
+++ b/playbooks/ORCHESTRATION.md
@@ -54,6 +54,8 @@ You will need the following variables for the online signer references described
 
 Ensure that these are the values reflected in the staging snapshot and timestamp [workflow](../.github/workflows/staging-snapshot-timestamp.yml).
 
+**NOTE** Ensure that the automated [snapshot and timestamp job](../.github/workflows/stable-snapshot-timestamp.yml) has triggered within the last 5 days. During the week of the ceremony, the job will not push automated updates, and expects the ceremony to be completed within one week. This is to ensure that snapshotting the main ceremony branch does not result in a merge conflict with the new ceremony event. See [693](https://github.com/sigstore/root-signing/issues/693).
+
 ## Step 1: Root Key Updates (Optional)
 
 Like mentioned in [Key configuration](#key-configuration), each root key corresponds to a subfolder named by its serial number. The [initialization](#step-2-initializing-a-root-and-targets) script automatically picks up any new subfolders and adds them to the root keys. Any subfolders that are removed are revoked from the root.


### PR DESCRIPTION

* Adds a check to detect PROD ceremony branches within 1 week of the job running. Automated workflows are blocked to ensure no merge conflict.
* Adds docs in ORCHESTRATION.md with reference and asking to ensure a recent run BEFORE the ceremony. The ceremony itself triggers a snapshot/timestamp so we should be good here, since we have a 2 week window and we will be ensuring that the jobs are run each week (before ceremony, from the ceremony, the week after)
* Adds a dry-run option to the workflow, so that I can pre-test my check.

Fixes https://github.com/sigstore/root-signing/issues/693

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->