### PR TITLE
ci: fix detection of wip ceremony branches

### DIFF
--- a/.github/workflows/stable-snapshot-timestamp.yml
+++ b/.github/workflows/stable-snapshot-timestamp.yml
@@ -59,10 +59,10 @@ jobs:
           ceremonyRegex="origin/ceremony/[0-9]{4}-[0-9]{2}-[0-9]{2}$"
           for branch in ${BRANCHES}
           do
-            if [[ "$branch" =~ $ceremonyRegex ]]; then
+            if [[ "$branch" =~ ${ceremonyRegex} ]]; then
               echo "found ceremony branch $branch"
-              branch_date=$(echo "$branch" | cut -d '/' -f3)
-              days_diff=$(( ($(date -d "00:00" +%s) - $(date -d "$branch_date" +%s)) / (24*3600) ))
+              branch_date=$(echo "${branch}" | cut -d '/' -f3)
+              days_diff=$(( ($(date -d "00:00" +%s) - $(date -d "${branch_date}" +%s)) / (24*3600) ))
               if [[ "$days_diff" -lt 7 ]]; then
                 # Detected ceremony within 7 days of current date
                 echo "detected ceremony branch $branch within 7 days, stopping automated cron"

--- a/.github/workflows/stable-snapshot-timestamp.yml
+++ b/.github/workflows/stable-snapshot-timestamp.yml
@@ -48,22 +48,25 @@ jobs:
           fetch-depth: 0
       - name: Determine whether to run a snapshot/timestamp
         id: check
+        shell: bash
         run: |
-          BRANCHES=$(git branch  | grep ceremony/)
+          set -euo pipefail
+
+          BRANCHES=$(git for-each-ref --format='%(refname:short)' | grep origin/ceremony/)
           echo "${BRANCHES}"
           # Check whether a ceremony was initiated within a week of the current date.
-          echo "wip=false" >> $GITHUB_OUTPUT
-          ceremony-re="^ceremony/[0-9]{4}-[0-9]{2}-[0-9]{2}$"
-          for branch in "${BRANCHES}"
+          echo "wip=false" >> "${GITHUB_OUTPUT}"
+          ceremonyRegex="origin/ceremony/[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+          for branch in ${BRANCHES}
           do
-            if [[ "$branch" ~= "$ceremony-re" ]]; then
+            if [[ "$branch" =~ $ceremonyRegex ]]; then
               echo "found ceremony branch $branch"
-              branch_date=$(echo "$branch" | cut -d '/' -f2)
-              days_diff=$(( (`date -d $branch_date +%s` - `date -d "00:00" +%s`) / (24*3600) ))
+              branch_date=$(echo "$branch" | cut -d '/' -f3)
+              days_diff=$(( ($(date -d "00:00" +%s) - $(date -d "$branch_date" +%s)) / (24*3600) ))
               if [[ "$days_diff" -lt 7 ]]; then
                 # Detected ceremony within 7 days of current date
                 echo "detected ceremony branch $branch within 7 days, stopping automated cron"
-                echo "wip=true" >> $GITHUB_OUTPUT
+                echo "wip=true" >> "${GITHUB_OUTPUT}"
               fi
             fi
           done


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
Fixes a handful of things:

* Adds logging
* Cannot use `git branch` in a shell script - fixed to `git for-each-ref` and updated the ref regexes
* Fixes the regex equality
* Fixes the days diff checking - the subtraction resulted in negative days, so swapped to correct this.

Ended up testing this in the draft version of this PR on the test presubmit

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->