### PR TITLE
Don't run sync workflow of ceremony branches in forked repos

### DIFF
--- a/.github/workflows/sync-ceremony-to-main.yml
+++ b/.github/workflows/sync-ceremony-to-main.yml
@@ -42,6 +42,7 @@ on:
 
 jobs:
   push:
+    if: (github.event_name == 'schedule' && github.repository == 'sigstore/root-signing') || (github.event_name != 'schedule')  # Don't run workflow in forks on cron
     permissions:
       pull-requests: 'write'
       contents: 'write'


### PR DESCRIPTION
#### Summary
Only run sync published ceremony branches to main in the `sigstore/root-signing` repo, not in forks.

#### Release Note
N/A

#### Documentation
N/A