### PR TITLE
Delegation documentation

### DIFF
--- a/playbooks/ORCHESTRATION.md
+++ b/playbooks/ORCHESTRATION.md
@@ -181,7 +181,8 @@ verification output.
 To manually verify the POP, run `./scripts/dpop-verify.sh ${PR_NUM}
 ${DELEGATION_NAME}`. Don't forget to ensure that `./scripts/verify.sh
 $PR` runs on the PR to validate the `targets.json` has a valid
-format. Merge the PR against the ceremony branch.
+format and that the delegation metadata is properly signed. 
+Merge the PR against the ceremony branch.
 
 ## Step 4: Hardware Key Signing
 

--- a/playbooks/ORCHESTRATION.md
+++ b/playbooks/ORCHESTRATION.md
@@ -144,7 +144,7 @@ As part of running the `add-delegaton` command, a POP (proof of
 possession) has to be generated too. The computed POP should be stored
 in `${REPO}/staged/${FORK_POINT}.sig`, where the fork point is the
 fork point from `main` and the ceremony branch. This fork point is
-also used as the nonce when computing the pop.
+also used as the nonce when computing the POP.
 
 The delegation keyholder would run these commands (on a branch based
 on the ceremony branch):

--- a/playbooks/ORCHESTRATION.md
+++ b/playbooks/ORCHESTRATION.md
@@ -185,7 +185,9 @@ format. Merge the PR against the ceremony branch.
 
 ## Step 4: Hardware Key Signing
 
-Next, the root and targets file must be signed. Ask each root keyholder to follow [Signing root and targets](../KEYHOLDER.md#signing-root-and-targets).
+Next, the root and targets file must be signed. Ask each root
+keyholder to follow [Signing root and
+targets](keyholders/EXISTING_SIGNER.md#signing).
 
 This will modify `root.json` and `targets.json` with an added signature.
 

--- a/playbooks/ORCHESTRATION.md
+++ b/playbooks/ORCHESTRATION.md
@@ -146,8 +146,8 @@ in `${REPO}/staged/${FORK_POINT}.sig`, where the fork point is the
 fork point from `main` and the ceremony branch. This fork point is
 also used as the nonce when computing the pop.
 
-The delegation keyholder would run these commands (on a branch from
-the ceremony branch):
+The delegation keyholder would run these commands (on a branch based
+on the ceremony branch):
 
 Create the delegation metadata
 ```shell
@@ -165,15 +165,15 @@ $ ./tuf sign \
 ```
 
 ```shell
-$ FORK_POINT=$(git merge-base --fork-point origin/main "${BRANCH}")
-./tuf key-pop-sign \
+$ FORK_POINT=$(git merge-base --fork-point origin/main "${BRANCH}") \
+      ./tuf key-pop-sign \
       -key ${KEY_REF} \
       -challenge ${DELEGATION_NAME} \
       -nonce ${FORK_POINT} > ${REPO}/staged/${FORK_POINT}.sig
 ```
 Here `BRANCH` is the ceremony branch, not the branch for the delegation.
 
-When the PR is open, it will trigger the POP verify
+When the PR is created, it will trigger the POP verify
 [workflow](../.github/workflows/delegation-pop-verify.yml), and upon
 successfull verification it will post a comment to the PR with the
 verification output.

--- a/playbooks/ORCHESTRATION.md
+++ b/playbooks/ORCHESTRATION.md
@@ -182,7 +182,7 @@ When the PR is created, it will trigger the POP verify
 successfull verification it will post a comment to the PR with the
 verification output.
 
-To manually verify the POP, run `./scripts/dpop-verify.sh ${PR_NUM}
+To manually verify the POP, run `./scripts/step-0.sh && ./scripts/dpop-verify.sh ${PR_NUM}
 ${DELEGATION_NAME}`. Don't forget to ensure that `./scripts/verify.sh
 $PR` runs on the PR to validate the `targets.json` has a valid
 format and that the delegation metadata is properly signed.

--- a/playbooks/ORCHESTRATION.md
+++ b/playbooks/ORCHESTRATION.md
@@ -145,7 +145,8 @@ As part of running the `add-delegaton` command, a POP (proof of
 possession) has to be generated too. The computed POP should be stored
 in `${REPO}/staged/${FORK_POINT}.sig`, where the fork point is the
 fork point from `main` and the ceremony branch. This fork point is
-also used as the nonce when computing the POP.
+also used as the nonce when computing the POP (via `tuf key-pop-sign`,
+see below for an examle).
 
 The delegation keyholder would run these commands (on a branch based
 on the ceremony branch):
@@ -182,7 +183,7 @@ verification output.
 To manually verify the POP, run `./scripts/dpop-verify.sh ${PR_NUM}
 ${DELEGATION_NAME}`. Don't forget to ensure that `./scripts/verify.sh
 $PR` runs on the PR to validate the `targets.json` has a valid
-format and that the delegation metadata is properly signed. 
+format and that the delegation metadata is properly signed.
 Merge the PR against the ceremony branch.
 
 ## Step 4: Hardware Key Signing

--- a/playbooks/ORCHESTRATION.md
+++ b/playbooks/ORCHESTRATION.md
@@ -133,12 +133,13 @@ This step will add a delegated role to the top-level targets that is
 controlled by an external GitHub repository. Coordinate with the
 delegation keyholder to run the `add-delegation` (see
 https://github.com/sigstore/root-signing/blob/main/cmd/tuf/app/add-delegation.go).
+When creating the delegation with the command, a `target-meta`
+file has to be provided that lists the targets, similar to adding
+the top level targets.
 After the delegation metadata is added and signed, the delegation
 keyholder should open a PR against the ceremony branch.
 The name of the PR MUST be `feat/add-delegation for
-<delegation-name>`. When creating the delegation, a  `target-meta`
-file has to be provided that lists the targets, similar when adding
-the top level targets.
+<delegation-name>`.
 
 As part of running the `add-delegaton` command, a POP (proof of
 possession) has to be generated too. The computed POP should be stored

--- a/playbooks/ORCHESTRATION.md
+++ b/playbooks/ORCHESTRATION.md
@@ -131,7 +131,7 @@ Manually check for:
 
 This step will add a delegated role to the top-level targets that is
 controlled by an external GitHub repository. Coordinate with the
-delegation keyholder to run the `add-delegation` (see
+delegation keyholder to run the `add-delegation` command (see
 https://github.com/sigstore/root-signing/blob/main/cmd/tuf/app/add-delegation.go).
 When creating the delegation with the command, a `target-meta`
 file has to be provided that lists the targets, similar to adding

--- a/playbooks/ORCHESTRATION.md
+++ b/playbooks/ORCHESTRATION.md
@@ -169,7 +169,7 @@ $ ./tuf sign \
 ```
 
 ```shell
-$ FORK_POINT=$(git merge-base --fork-point origin/main "${BRANCH}") \
+$ FORK_POINT=$(git merge-base origin/main "${BRANCH}") \
       ./tuf key-pop-sign \
       -key ${KEY_REF} \
       -challenge ${DELEGATION_NAME} \

--- a/playbooks/ORCHESTRATION.md
+++ b/playbooks/ORCHESTRATION.md
@@ -184,7 +184,7 @@ To manually verify the POP, run `./scripts/dpop-verify.sh ${PR_NUM}
 ${DELEGATION_NAME}`. Don't forget to ensure that `./scripts/verify.sh
 $PR` runs on the PR to validate the `targets.json` has a valid
 format and that the delegation metadata is properly signed.
-Merge the PR against the ceremony branch.
+Assuming verification passes, merge the PR against the ceremony branch.
 
 ## Step 4: Hardware Key Signing
 

--- a/playbooks/ORCHESTRATION.md
+++ b/playbooks/ORCHESTRATION.md
@@ -178,9 +178,7 @@ $ FORK_POINT=$(git merge-base origin/main "${BRANCH}") \
 Here `BRANCH` is the ceremony branch, not the branch for the delegation.
 
 When the PR is created, it will trigger the POP verify
-[workflow](../.github/workflows/delegation-pop-verify.yml), and upon
-successfull verification it will post a comment to the PR with the
-verification output.
+[workflow](../.github/workflows/delegation-pop-verify.yml).
 
 To manually verify the POP, run `./scripts/step-0.sh && ./scripts/dpop-verify.sh ${PR_NUM}
 ${DELEGATION_NAME}`. Don't forget to ensure that `./scripts/verify.sh

--- a/playbooks/ORCHESTRATION.md
+++ b/playbooks/ORCHESTRATION.md
@@ -135,7 +135,9 @@ delegation keyholder to run the `add-delegation` command (see
 https://github.com/sigstore/root-signing/blob/main/cmd/tuf/app/add-delegation.go).
 When creating the delegation with the command, a `target-meta`
 file has to be provided that lists the targets, similar to adding
-the top level targets.
+the top level targets, see
+[here](ORCHESTRATION.md#targets-and-delegation-configuration) for an
+example.
 After the delegation metadata is added and signed, the delegation
 keyholder should open a PR against the ceremony branch.
 The name of the PR MUST be `feat/add-delegation for

--- a/playbooks/ORCHESTRATION.md
+++ b/playbooks/ORCHESTRATION.md
@@ -146,7 +146,7 @@ possession) has to be generated too. The computed POP should be stored
 in `${REPO}/staged/${FORK_POINT}.sig`, where the fork point is the
 fork point from `main` and the ceremony branch. This fork point is
 also used as the nonce when computing the POP (via `tuf key-pop-sign`,
-see below for an examle).
+see below for an example).
 
 The delegation keyholder would run these commands (on a branch based
 on the ceremony branch):


### PR DESCRIPTION
#### Summary
Closes https://github.com/sigstore/root-signing/issues/703
Adds documentation on how to add a delegation during a signing ceremony.

[Rendered version](https://github.com/kommendorkapten/root-signing/blob/delegation_documentaton/playbooks/ORCHESTRATION.md)

#### Release Note
N/A

#### Documentation
This PR is the updated documentation