### PR TITLE
Dont try to add a comment back after verifying the pop.

### DIFF
--- a/.github/workflows/scripts/dpop-wrapper.sh
+++ b/.github/workflows/scripts/dpop-wrapper.sh
@@ -26,7 +26,3 @@ TITLE=$1
 DELEGATION=$(echo "${TITLE}" | sed -E 's/(.+) for (.+)/\2/')
 OUTPUT=$(mktemp)
 ./scripts/dpop-verify.sh "${DELEGATION}" 2>&1 | tee "${OUTPUT}"
-
-# If we made it here, signature verification was successful.
-# Add a comment with the output
-GH_TOKEN=${GITHUB_TOKEN} gh pr comment "${PR_NUMBER}" -F "${OUTPUT}"


### PR DESCRIPTION
As pull_request targets don't have access to secrets, this will fail. Instead rely on the workflow failing to detect when a pop is not valid.

Closes https://github.com/sigstore/root-signing/issues/743

#### Summary
See above, don't try to add a comment after successful verification as it will fail due to `pull_request` targets not having access to secrets.

N/A