### PR TITLE
Use local main when computing the merge base

### DIFF
--- a/scripts/dpop-verify.sh
+++ b/scripts/dpop-verify.sh
@@ -19,7 +19,7 @@ set -o errexit
 set -o xtrace
 set -u
 
-MERGE_BASE=origin/main
+MERGE_BASE=main
 
 if [ $# -gt 1 ]; then
     # params are: PR DELEGATION_NAME


### PR DESCRIPTION


#### Summary
To avoid having each user their `origin` up to date, rely on local `main` when computing the merge base`.

#### Release Note


#### Documentation
