### PR TITLE
fix: fix handling null custom metadata values in delegations

### DIFF
--- a/cmd/tuf/app/add-delegation.go
+++ b/cmd/tuf/app/add-delegation.go
@@ -185,6 +185,13 @@ func DelegationCmd(ctx context.Context, opts *DelegationOptions) error {
 		}
 
 		for tt, custom := range meta.Add {
+			if string(custom) == "null" {
+				// As an artifact of using YAML to encode the config, empty values
+				// result in "null" string keywords. This does not occur in the top-level
+				// targets, because we marshal the payload to JSON in setMetaWithSigKeyIDs
+				// which converts the null value to empty.
+				custom = nil
+			}
 			from, err := os.Open(tt)
 			if err != nil {
 				return err

--- a/cmd/tuf/app/init.go
+++ b/cmd/tuf/app/init.go
@@ -17,6 +17,7 @@ package app
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -218,7 +219,11 @@ func InitCmd(ctx context.Context, directory string,
 			return err
 		}
 		fmt.Fprintln(os.Stderr, "Created target file at ", to.Name())
-		if err := repo.AddTargetWithExpiresToPreferredRole(tt, custom, GetExpiration("targets"), "targets"); err != nil {
+		var customMetadata json.RawMessage
+		if custom != nil {
+			customMetadata = *custom
+		}
+		if err := repo.AddTargetWithExpiresToPreferredRole(tt, customMetadata, GetExpiration("targets"), "targets"); err != nil {
 			return fmt.Errorf("error adding targets %w", err)
 		}
 		expectedTargets[tt] = true

--- a/pkg/repo/repo.go
+++ b/pkg/repo/repo.go
@@ -186,22 +186,9 @@ func GetMetaFromStore(msg []byte, name string) (interface{}, error) {
 	return meta, nil
 }
 
-// Target metadata helpers
-func SigstoreTargetMetaFromString222(b []byte) (map[string]json.RawMessage, error) {
-	jsonBytes, err := kyaml.YAMLToJSON(b)
-	if err != nil {
-		return nil, err
-	}
-	var targetsMetaJSON map[string]json.RawMessage
-	if err := json.Unmarshal(jsonBytes, &targetsMetaJSON); err != nil {
-		return nil, err
-	}
-	return targetsMetaJSON, nil
-}
-
 type TargetMetaConfig struct {
-	Add map[string]json.RawMessage `json:"add"`
-	Del map[string]json.RawMessage `json:"delete"`
+	Add map[string]json.RawMessage `json:"add,omitempty"`
+	Del map[string]json.RawMessage `json:"delete,omitempty"`
 }
 
 func SigstoreTargetMetaFromString(b []byte) (*TargetMetaConfig, error) {

--- a/pkg/repo/repo.go
+++ b/pkg/repo/repo.go
@@ -187,8 +187,8 @@ func GetMetaFromStore(msg []byte, name string) (interface{}, error) {
 }
 
 type TargetMetaConfig struct {
-	Add map[string]json.RawMessage `json:"add,omitempty"`
-	Del map[string]json.RawMessage `json:"delete,omitempty"`
+	Add map[string]*json.RawMessage `json:"add,omitempty"`
+	Del map[string]*json.RawMessage `json:"delete,omitempty"`
 }
 
 func SigstoreTargetMetaFromString(b []byte) (*TargetMetaConfig, error) {
@@ -200,6 +200,7 @@ func SigstoreTargetMetaFromString(b []byte) (*TargetMetaConfig, error) {
 	if err := json.Unmarshal(jsonBytes, &targetsMetaJSON); err != nil {
 		return nil, err
 	}
+
 	return &targetsMetaJSON, nil
 }
 

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -77,8 +77,6 @@ case $input in
     3)
         echo "Enter comma-separated target names to verify. If blank, all top-level targets will be verified:"
         read -r targets
-        echo "no " ${targets:+--targets $targets}
-        echo "no col" ${targets+--targets $targets}
 
         # If published data exists, verify against a root
         if [ -f "$REPO"/repository/1.root.json ]; then

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -777,10 +777,12 @@ func TestProdTargetsConfig(t *testing.T) {
 	// Validate presence of custom metadata per configuration.
 	for name, tFiles := range targetFiles {
 		var v1, v2 interface{}
-		json.Unmarshal([]byte(targetsConfig.Add[name]), &v1)
+		if targetsConfig.Add[name] != nil {
+			json.Unmarshal([]byte(*targetsConfig.Add[name]), &v1)
+		}
 		if tFiles.Custom == nil {
-			if v2 != nil {
-				t.Errorf("no custom metadata found, expected: %s", v2)
+			if v1 != nil {
+				t.Errorf("no custom metadata found, expected: %s", v1)
 			}
 			continue
 		}

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -75,8 +75,8 @@ func newRepoTestStack(ctx context.Context, t *testing.T) *repoTestStack {
 		hsmRootCA:     rootCA,
 		hsmRootSigner: rootSigner,
 		targetsConfig: &repo.TargetMetaConfig{
-			Add: map[string]json.RawMessage{},
-			Del: map[string]json.RawMessage{},
+			Add: map[string]*json.RawMessage{},
+			Del: map[string]*json.RawMessage{},
 		},
 		snapshotRef:  createTestSigner(t),
 		timestampRef: createTestSigner(t),
@@ -88,7 +88,7 @@ func (s *repoTestStack) addTarget(t *testing.T, name, content string, custom jso
 	if err := os.WriteFile(testTarget, []byte(content), 0600); err != nil {
 		t.Fatal(err)
 	}
-	s.targetsConfig.Add[name] = custom
+	s.targetsConfig.Add[name] = &custom
 }
 
 func (s *repoTestStack) removeTarget(t *testing.T, name string) {


### PR DESCRIPTION
Ultimately, this fixes signature verification for delegated target metadata files.

I noticed that we were adding `"custom": null` values into the targets in https://github.com/sigstore/root-signing/pull/742
```
		"targets": {
			"registry.npmjs.org/keys.json": {
				"length": 686,
				"hashes": {
					"sha256": "b9a18e4adde4a133526766b53f3519fd93e1531a71ade2ab30f3b4faeb0d7cdf",
					"sha512": "e1db855026127f6b824bf1a36f7b2a749a225decac3e7d10655fac8f2d7c23b770e2a7d609ea265a74788d944bbab9aca90655e509347930c8a11786715ce517"
				},
				"custom": null
			}
		}
```

This does not occur in the top-level targets, even when custom metadata is empty, as it is for [trusted_root](https://github.com/sigstore/root-signing/blob/main/config/targets-metadata.yml#L37). Debugging, I found:

* Unmarshalling null values in YAML results in the "null" KEYWORD string, which was causing a STRING value null metadata for the delegations.
* This does not show in top-level targets because we happen to marshal into JSON by hand, which  removes the payload [here](https://github.com/sigstore/root-signing/blob/d51ecc6840d06f16ca8842a8df069d935efe74cd/cmd/tuf/app/init.go#L277)
* The delegation addition code uses go-tuf repository API, and for whatever reason, the null value is not removed in their marshalling
* This failed signature verification, because when you construct the signature, you read and marshal into canonical JSON - the "null" then disappears, and the signature payload has the "custom": null payload removed.

I considered manipulating the method where we read the config by re-marshaling it through JSON and back but it didn't remove the null value because we were using a `json.RawMessage`.

Finally, I decided to change the `json.RawMessage` to a pointer instead, which would be nil if the custom metadata was nil, rather than write a `null` string. 

The only alternative would be to re-marshal the final target metadata as JSON and write that back to the store, but I figured this is more clear for a user who does not understand internals.
