### PR TITLE
Origin main in workflows

### DIFF
--- a/scripts/dpop-verify.sh
+++ b/scripts/dpop-verify.sh
@@ -19,13 +19,15 @@ set -o errexit
 set -o xtrace
 set -u
 
-MERGE_BASE=main
+MERGE_BASE=origin/main
 
 if [ $# -gt 1 ]; then
     # params are: PR DELEGATION_NAME
     # Intended for users locally verifying a PR that contains a POP
     PR=$1
     DELEGATION=$2
+    # Use local branch when running locally
+    MERGE_BASE=main
 
     REPO=${REPO:-./repository}
     LOCAL=${LOCAL:-}

--- a/scripts/dpop-verify.sh
+++ b/scripts/dpop-verify.sh
@@ -46,7 +46,7 @@ if [ $# -gt 1 ]; then
     git checkout VERIFY
 
 else
-  # params are: PR
+  # params are: DELEGATION_NAME
   # Intended for usage inside a GitHub workflow context where the
   # pull request has already been checked out.
     DELEGATION=$1


### PR DESCRIPTION
Revert to using origin/main as merge base when running inside actions.

    The workflow does not fetch main, only the active branch.
    Using origin/main works as that's how it was done before, but it
    did cause issues when running the script locally if the user did not
    have their origin up-to-date, so we switched to using only main. But
    that breaks the PR workflows, this fix changes so in a workflow we
    use origin/main, but when running locally it uses main.

    Signed-off-by: Fredrik Skogman <kommendorkapten@github.com>

#### Summary


#### Release Note
N/A

#### Documentation
N/A