### PR TITLE
Add flag to force a snapshot/timestamp generation

### DIFF
--- a/.github/workflows/stable-snapshot-timestamp.yml
+++ b/.github/workflows/stable-snapshot-timestamp.yml
@@ -35,6 +35,11 @@ on:
         type: boolean
         default: false
         description: Does not trigger job, but checks on whether the job should run.
+      force_snapshot:
+        description: 'Whether to force a snapshot. Useful if workflow is within 7 days of a ceremony'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   check:
@@ -73,7 +78,7 @@ jobs:
 
   run_snapshot_timestamp_publish:
     needs: check
-    if: (github.event_name == 'schedule' && github.repository == 'sigstore/root-signing' && needs.check.outputs.ceremony_wip == 'false') || (github.event_name != 'schedule' && inputs.dry_run == 'false')  # Don't run workflow in forks on cron
+    if: (github.event_name == 'schedule' && github.repository == 'sigstore/root-signing' && needs.check.outputs.ceremony_wip == 'false') || (github.event_name != 'schedule' && inputs.dry_run == 'false') || (inputs.force_snapshot == 'true')  # Don't run workflow in forks on cron
     permissions:
       id-token: 'write'
       issues: 'write'


### PR DESCRIPTION
This allows us to regenerate the metadata during the 7 day period after a root signing event

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
