### PR TITLE
Support Unix timestamps for verify, sync preprod more

### DIFF
--- a/.github/workflows/sync-preprod-to-prod.yml
+++ b/.github/workflows/sync-preprod-to-prod.yml
@@ -17,11 +17,11 @@ name: Sync Preprod Repository with GCS Prod Bucket
 
 on:
   schedule:
-    - cron: '0 */6 * * *' # every 6 hours
+    - cron: '0 */1 * * *' # every 1 hour
   workflow_dispatch:
     inputs:
       trigger_sync:
-        description: 'Whether to manually trigger a sync, otherwise only syncs pre-prod to prod with a 2 day delay'
+        description: 'Whether to manually trigger a sync, otherwise pre-prod to prod syncs with a 1 day delay'
         required: false
         default: false
         type: boolean


### PR DESCRIPTION
This will verify that the timestamp expires at a more precise time than the day granularity. Also increase how often the GHA runs to sync preprod so it happens closer to 1 day after metadata is generated.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
