### PR TITLE
Switch metadata regeneration to Tues/Fri

### DIFF
--- a/.github/workflows/stable-snapshot-timestamp.yml
+++ b/.github/workflows/stable-snapshot-timestamp.yml
@@ -22,7 +22,7 @@ permissions: read-all
 on:
   # Enable cron for re-signing snapshot and timestamp every week
   schedule:
-    - cron: '0 16 * * 1' # every Monday at 9am PST
+    - cron: '0 16 * * 2' # every Tuesday at 9am PST
   # When a new root is staged
   push:
     branches:

--- a/.github/workflows/stable-timestamp.yml
+++ b/.github/workflows/stable-timestamp.yml
@@ -19,10 +19,10 @@ permissions: read-all
 
 # Execute this as a once a week cron job (in addition to stable-snapshot-timestamp)
 on:
-  # Enable cron for re-signing timestamp every week, mid week. Timestamp is also
+  # Enable cron for re-signing timestamp every week. Timestamp is also
   # regenerated in stable-snapshot-timestamp.yml
   schedule:
-    - cron: '0 16 * * 4' # every Thursday at 9am PST
+    - cron: '0 16 * * 5' # every Friday at 9am PST
   workflow_dispatch:
     inputs:
       dry_run:


### PR DESCRIPTION
This makes it more likely that we'll catch expiration issues during the work week.

Fixes #894

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
