### PR TITLE
Use PR title when auto-merging PRs

### DIFF
--- a/.github/workflows/scripts/review-pull-request.sh
+++ b/.github/workflows/scripts/review-pull-request.sh
@@ -26,8 +26,10 @@ timestamp_update() {
 UPDATE_PR=$(timestamp_update)
 if [[ -n "${UPDATE_PR}" ]]; then
     PULL_NUMBER=$(echo "${UPDATE_PR}" | jq -r '.number')
+    TITLE=$(echo "${UPDATE_PR}" | jq -r '.title')
     echo "pull request found: "
     echo "${PULL_NUMBER}"
+    echo "${TITLE}"
 
     # Approve PR
     curl \
@@ -59,7 +61,7 @@ if [[ -n "${UPDATE_PR}" ]]; then
     --method PUT \
     -H "Accept: application/vnd.github+json" \
     /repos/"${GITHUB_REPOSITORY}"/pulls/"${PULL_NUMBER}"/merge \
-    -f commit_title="Update Snapshot and Timestamp (#${PULL_NUMBER})" \
+    -f commit_title="${TITLE} (#${PULL_NUMBER})" \
     -f commit_message="Signed-off-by: ${LOGIN} <${LOGIN}@users.noreply.github.com>" \
     -f merge_method='squash'
 


### PR DESCRIPTION
PR title might be "Update Timestamp" if only a timestamp is updated

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
