### PR TITLE
[TEST] Bumped version and signed delegation

### DIFF
--- a/repository/staged/registry.npmjs.org.json
+++ b/repository/staged/registry.npmjs.org.json
@@ -1,0 +1,23 @@
+{
+	"signed": {
+		"_type": "targets",
+		"spec_version": "1.0",
+		"version": 9,
+		"expires": "2024-03-12T15:34:35Z",
+		"targets": {
+			"registry.npmjs.org/keys.json": {
+				"length": 1017,
+				"hashes": {
+					"sha256": "7a8ec9678ad824cdccaa7a6dc0961caf8f8df61bc7274189122c123446248426",
+					"sha512": "881a853ee92d8cf513b07c164fea36b22a7305c256125bdfffdc5c65a4205c4c3fc2b5bcc98964349167ea68d40b8cd02551fcaa870a30d4601ba1caf6f63699"
+				}
+			}
+		}
+	},
+	"signatures": [
+		{
+			"keyid": "a89d235ee2f298d757438c7473b11b0b7b42ff1a45f1dfaac4c014183d6f8c45",
+			"sig": "3044022044a360b6c803d7bb27a07887d35a22f9c47c02023528416cbd5ef4a8d361f6a302202a2f83be46fb9a43e2c312ab4d53a65d323a3ab9e44a77ae60354033428231c2"
+		}
+	]
+}

--- a/repository/staged/targets.json
+++ b/repository/staged/targets.json
@@ -3,7 +3,7 @@
 		"_type": "targets",
 		"spec_version": "1.0",
 		"version": 8,
-		"expires": "2024-03-12T13:22:55Z",
+		"expires": "2024-03-12T15:34:35Z",
 		"targets": {
 			"artifact.pub": {
 				"length": 177,
@@ -109,6 +109,34 @@
 					"sha512": "fdebade075c4840d40f1806a14d0660ae1d22f47c0516abc4141e09f4ddf6ee6f4dbfbf08a7025bea10a4b8794658a4cd8ebb1024b963f239a9bfe02c2057fc6"
 				}
 			}
+		},
+		"delegations": {
+			"keys": {
+				"a89d235ee2f298d757438c7473b11b0b7b42ff1a45f1dfaac4c014183d6f8c45": {
+					"keytype": "ecdsa-sha2-nistp256",
+					"scheme": "ecdsa-sha2-nistp256",
+					"keyid_hash_algorithms": [
+						"sha256",
+						"sha512"
+					],
+					"keyval": {
+						"public": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEoLrh0jmOfHWLwsyo/4oGbldF91WV\nfXvxVlDhW8fZwP/3vTnliBkDp5sH8/Dpm1SBOHkqENVt1+4Un/sFtl2zAQ==\n-----END PUBLIC KEY-----\n"
+					}
+				}
+			},
+			"roles": [
+				{
+					"name": "registry.npmjs.org",
+					"keyids": [
+						"a89d235ee2f298d757438c7473b11b0b7b42ff1a45f1dfaac4c014183d6f8c45"
+					],
+					"threshold": 1,
+					"terminating": true,
+					"paths": [
+						"registry.npmjs.org/*"
+					]
+				}
+			]
 		}
 	},
 	"signatures": [

--- a/repository/staged/targets/registry.npmjs.org/keys.json
+++ b/repository/staged/targets/registry.npmjs.org/keys.json
@@ -1,0 +1,26 @@
+{
+    "keys": [
+        {
+            "keyId": "SHA256:jl3bwswu80PjjokCgh0o2w5c2U4LhQAE57gj9cz1kzA",
+            "keyUsage": "npm:signatures",
+            "publicKey": {
+                "rawBytes": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE1Olb3zMAFFxXKHiIkQO5cJ3Yhl5i6UPp+IhuteBJbuHcA5UogKo0EWtlWwW6KSaKoTNEYL7JlCQiVnkhBktUgg==",
+                "keyDetails": "PKIX_ECDSA_P256_SHA_256",
+                "validFor": {
+                    "start": "1999-01-01T00:00:00.000Z"
+                }
+            }
+        },
+        {
+            "keyId": "SHA256:jl3bwswu80PjjokCgh0o2w5c2U4LhQAE57gj9cz1kzA",
+            "keyUsage": "npm:attestations",
+            "publicKey": {
+                "rawBytes": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE1Olb3zMAFFxXKHiIkQO5cJ3Yhl5i6UPp+IhuteBJbuHcA5UogKo0EWtlWwW6KSaKoTNEYL7JlCQiVnkhBktUgg==",
+                "keyDetails": "PKIX_ECDSA_P256_SHA_256",
+                "validFor": {
+                    "start": "2022-12-01T00:00:00.000Z"
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
# TEST ONLY

Bumped version and updated expiration of npm delegation. Note that his has to be done manually as step 1.5 does not carry over delegations. This PR is informative only.

I will go over the documentation and update any sections on how to updates that are not updated.

# What to look for
* The delegation metadata should be identical to https://github.com/sigstore/root-signing/blob/main/repository/repository/1.registry.npmjs.org.json except for the signature, version and expiration.
* The delegation in `targets.json` should match https://github.com/sigstore/root-signing/blob/9ad7427b161486773dd3d89931ef0306d30fe5d1/repository/repository/7.targets.json#L113 byte-for-byte

