### PR TITLE
Updated the description on how to update a delegation during a signing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,10 @@ keygen:
 tuf:
 	@go build -tags=pivkey -o $@ ./cmd/tuf
 
+.PHONY: verify
+verify:
+	@go build -o verify ./cmd/verify
+
 .PHONY: test
 test:
 	@go test -tags=pivkey ./...

--- a/playbooks/ORCHESTRATION.md
+++ b/playbooks/ORCHESTRATION.md
@@ -168,6 +168,20 @@ $ ./tuf add-delegation -name ${DELEGATION_NAME} \
       -repository repository
 ```
 
+:information_source: The `delegate-meta.yaml` file has the same format
+as [config/targets-metadata.yml](../config/targets-metadata.yml). The
+`delegated/targets` directory should contain the targets for the
+delegate. As an example, this is how it looks for the
+`registry.npmjs.org` delegate:
+
+```shell
+$ ls registry.npmjs.org
+keys.json
+$ cat delegate-meta.yaml
+add:
+  registry.npmjs.org/keys.json:
+```
+
 ```shell
 $ ./tuf sign \
       -roles ${DELEGATION_NAME} \
@@ -233,6 +247,20 @@ $ tuf add-delegation \
       -name ${DELEGATION_NAME} \
       -target-meta delegate-meta.yaml \
       -public-key delegate.pem
+```
+
+:information_source: The `delegate-meta.yaml` file has the same format
+as [config/targets-metadata.yml](../config/targets-metadata.yml). The
+`delegated/targets` directory should contain the targets for the
+delegate. As an example, this is how it looks for the
+`registry.npmjs.org` delegate:
+
+```shell
+$ ls registry.npmjs.org
+keys.json
+$ cat delegate-meta.yaml
+add:
+  registry.npmjs.org/keys.json:
 ```
 
 This stages the updated version of the delegation, but the version is
@@ -346,20 +374,3 @@ Submitting this PR will trigger a push to the preproduction GCS bucket, so ensur
 #### Encountering a configuration mistake
 
 In case there is a configuration mistake or a breakage that renders a ceremony ineffective, move the half-completed ceremony directory into `ceremony/defunct`. This may help avoid keyholders from pointing to an invalid ceremony directory when signing.
-
-#### Adding a Delegation
-
-1. Add an environment variable for the delegation key named `$DELEGATION_KEY` in [./scripts/step-1.5.sh].
-
-2. Create a `./config/$DELEGATION-metadata`.yml file, see [Target and Delegation configuration](#targets-and-delegation-configuration).
-
-3. Edit [./scripts/step-1.5.sh] to add the delegation after the root and targets are setup via `tuf init`, with a command like:
-
-```bash
-# Add $DELEGATION delegation
-./tuf add-delegation -repository $REPO -name "$DELEGATION" -key $DELEGATION_KEY -target-meta config/$DELEGATION-metadata.yml -path $PATH
-```
-
-The optional `-path $PATH` specifies any [paths](https://theupdateframework.github.io/specification/latest/#delegation-role-paths) that describes paths the delegated role is trusted to provide.
-
-4. Update the [../README.md] with the delegation information in [Repository Structure](../README.md#tuf-repository-structure).

--- a/playbooks/ORCHESTRATION.md
+++ b/playbooks/ORCHESTRATION.md
@@ -293,7 +293,7 @@ This will modify `root.json` and `targets.json` with an added signature.
 Verify their PRs with the PR number as the argument to the script:
 
 ```bash
-./scripts/verify.sh $PR
+$ GITHUB_USER=<your GitHub handle> ./scripts/verify.sh $PR
 ```
 
 You should expect 1 signature added to root and targets on each PR.
@@ -301,7 +301,7 @@ You should expect 1 signature added to root and targets on each PR.
 After each of the root keyholder PRs are merged, run verification at the head of the ceremony branch:
 
 ```bash
-./scripts/verify.sh
+$ GITHUB_USER=<your GitHub handle> ./scripts/verify.sh
 ```
 
 and verify that the root and targets are fully signed.
@@ -318,7 +318,7 @@ This will create a PR signing the snapshot and timestamp files and committed the
 Verify the expirations and the signatures:
 
 ```bash
-./scripts/verify.sh $PR
+$ GITHUB_USER=<your GitHub handle> ./scripts/verify.sh $PR
 ```
 
 Note: You cannot test this step locally against the current staged repository, since the snapshot and timestamp keys are only given permissions to the GitHub Workflows. However, under the hood, the workflow is running `./scripts/step-3.sh` and `./scripts/step-4.sh`. If you initialize a ceremony with local testing keys, this action will work.

--- a/playbooks/ORCHESTRATION.md
+++ b/playbooks/ORCHESTRATION.md
@@ -195,18 +195,18 @@ Assuming verification passes, merge the PR against the ceremony branch.
 
 ## Step 4: Update delegation(s) (Optional)
 
-After the new (updated) repository is staged, the delegations are
-_not_ carried over, they must be added back manually. This operation
-should be coordinate with a key owner of the delegatee.
+After the new (updated) repository is staged, delegations are _not_
+carried over, they must be added back manually. This operation should
+be coordinated with a key owner of the delegatee.
 
 The recommended flow is that a key owner of the delegatee performs the
-follwoing steps in another branch then the ceremony branch, and
-prepares a PR, this [this
+follwoing steps in another branch than the ceremony branch, and
+prepares a PR, see this [this
 PR](https://github.com/sigstore/root-signing/pull/955) for an
 example.
 
-:information_source: Identify the key id for the public key for the
-delegation,
+:information_source: Identify the delegation's key id before
+proceeding
 e.g. `a89d235ee2f298d757438c7473b11b0b7b42ff1a45f1dfaac4c014183d6f8c45`.
 
 Use this key id to extract the public key for the delegate, as it's
@@ -222,10 +222,10 @@ $ cat repository/repository/targets.json | \
 :warning: Updating a delegation **must not** change the key, only the
 metadata, hence it's important to use the known key.
 
-Now add the previous delegation file and update it:
+Now add back the previous delegation file and update it:
 
 ```shell
-$ cp repository/repository/registry.npmjs.org.json repository/staged
+$ cp repository/${DELEGATION_NAME}.json repository/staged
 $ cp -r /path/to/delegated/targets .
 $ cp /path/to/delegate-meta.yaml .
 $ tuf add-delegation \

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -38,7 +38,7 @@ setup_forks
 checkout_branch
 
 # build the verification binary
-go build -o verify ./cmd/verify
+make verify
 [ -f piv-attestation-ca.pem ] || curl -fsO https://developers.yubico.com/PIV/Introduction/piv-attestation-ca.pem
 
 # Fetch the pull request if specified and verify


### PR DESCRIPTION
Adds a section for the orchestrator on how to update a delegation during a signing ceremony. 
[Rendered version](https://github.com/kommendorkapten/root-signing/blob/update-delegation-steps/playbooks/ORCHESTRATION.md#step-4-update-delegations-optional)

#### Summary


#### Release Note
N/A

#### Documentation
This PR only updates the documentation.