### PR TITLE
When checkout out the repo, use the provided branch

### DIFF
--- a/.github/workflows/reuseable-snapshot-timestamp.yml
+++ b/.github/workflows/reuseable-snapshot-timestamp.yml
@@ -188,6 +188,7 @@ jobs:
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
         with:
           fetch-depth: 0
+          ref: ${{ inputs.branch }}
       - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v2.1.0
         with:
           name: snapshot-timestamp


### PR DESCRIPTION
#### Summary

The patch is made from the checked out branch, but without it the patch is attempted to be applied against main, which will brake.

This way of working with patches was introduced in https://github.com/sigstore/root-signing/pull/784, so it has never been tested for a signing ceremony before.

Closes https://github.com/sigstore/root-signing/issues/968

#### Release Note
N/A

#### Documentation
N/A