### PR TITLE
Bumped npm delegate to v2 and resigned.

### DIFF
--- a/repository/staged/registry.npmjs.org.json
+++ b/repository/staged/registry.npmjs.org.json
@@ -1,0 +1,23 @@
+{
+	"signed": {
+		"_type": "targets",
+		"spec_version": "1.0",
+		"version": 2,
+		"expires": "2024-03-26T05:51:49Z",
+		"targets": {
+			"registry.npmjs.org/keys.json": {
+				"length": 1017,
+				"hashes": {
+					"sha256": "7a8ec9678ad824cdccaa7a6dc0961caf8f8df61bc7274189122c123446248426",
+					"sha512": "881a853ee92d8cf513b07c164fea36b22a7305c256125bdfffdc5c65a4205c4c3fc2b5bcc98964349167ea68d40b8cd02551fcaa870a30d4601ba1caf6f63699"
+				}
+			}
+		}
+	},
+	"signatures": [
+		{
+			"keyid": "a89d235ee2f298d757438c7473b11b0b7b42ff1a45f1dfaac4c014183d6f8c45",
+			"sig": "3046022100e7fac1f705f006f351a7b9050403bc4e75843a0376d489c5bc0cb4c77019512a022100c911301e106de5e3e3029fe686b8a069f1d96f1f6cdbd894ddc3bf0d45200de9"
+		}
+	]
+}

--- a/repository/staged/targets.json
+++ b/repository/staged/targets.json
@@ -3,7 +3,7 @@
 		"_type": "targets",
 		"spec_version": "1.0",
 		"version": 8,
-		"expires": "2024-03-26T04:38:55Z",
+		"expires": "2024-03-26T05:51:49Z",
 		"targets": {
 			"artifact.pub": {
 				"length": 177,
@@ -109,6 +109,34 @@
 					"sha512": "fdebade075c4840d40f1806a14d0660ae1d22f47c0516abc4141e09f4ddf6ee6f4dbfbf08a7025bea10a4b8794658a4cd8ebb1024b963f239a9bfe02c2057fc6"
 				}
 			}
+		},
+		"delegations": {
+			"keys": {
+				"a89d235ee2f298d757438c7473b11b0b7b42ff1a45f1dfaac4c014183d6f8c45": {
+					"keytype": "ecdsa-sha2-nistp256",
+					"scheme": "ecdsa-sha2-nistp256",
+					"keyid_hash_algorithms": [
+						"sha256",
+						"sha512"
+					],
+					"keyval": {
+						"public": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEoLrh0jmOfHWLwsyo/4oGbldF91WV\nfXvxVlDhW8fZwP/3vTnliBkDp5sH8/Dpm1SBOHkqENVt1+4Un/sFtl2zAQ==\n-----END PUBLIC KEY-----\n"
+					}
+				}
+			},
+			"roles": [
+				{
+					"name": "registry.npmjs.org",
+					"keyids": [
+						"a89d235ee2f298d757438c7473b11b0b7b42ff1a45f1dfaac4c014183d6f8c45"
+					],
+					"threshold": 1,
+					"terminating": true,
+					"paths": [
+						"registry.npmjs.org/*"
+					]
+				}
+			]
 		}
 	},
 	"signatures": [

--- a/repository/staged/targets/registry.npmjs.org/keys.json
+++ b/repository/staged/targets/registry.npmjs.org/keys.json
@@ -1,0 +1,26 @@
+{
+    "keys": [
+        {
+            "keyId": "SHA256:jl3bwswu80PjjokCgh0o2w5c2U4LhQAE57gj9cz1kzA",
+            "keyUsage": "npm:signatures",
+            "publicKey": {
+                "rawBytes": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE1Olb3zMAFFxXKHiIkQO5cJ3Yhl5i6UPp+IhuteBJbuHcA5UogKo0EWtlWwW6KSaKoTNEYL7JlCQiVnkhBktUgg==",
+                "keyDetails": "PKIX_ECDSA_P256_SHA_256",
+                "validFor": {
+                    "start": "1999-01-01T00:00:00.000Z"
+                }
+            }
+        },
+        {
+            "keyId": "SHA256:jl3bwswu80PjjokCgh0o2w5c2U4LhQAE57gj9cz1kzA",
+            "keyUsage": "npm:attestations",
+            "publicKey": {
+                "rawBytes": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE1Olb3zMAFFxXKHiIkQO5cJ3Yhl5i6UPp+IhuteBJbuHcA5UogKo0EWtlWwW6KSaKoTNEYL7JlCQiVnkhBktUgg==",
+                "keyDetails": "PKIX_ECDSA_P256_SHA_256",
+                "validFor": {
+                    "start": "2022-12-01T00:00:00.000Z"
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
#### Summary
Update and resigned npm delegation. 
What to verify:
* Version should be 2
* Expiration 2024-03-26
* Public key same as published (v7) repo
* registry.npmjs.org/keys.json should be identical as the one published

To verify with `verify` command, expected outcome should be:

```shell
 ./verify repository --repository ./re
pository --staged
STAGED METADATA

Outputting metadata verification at ./repository...

Verifying registry.npmjs.org.json...
	Success! Signatures valid and threshold achieved
	registry.npmjs.org version 2, expires 2024/03/26
Bumped npm delegate to v2 and resigned.

Verifying root.json...
	Contains 0/3 valid signatures from the current staged metadata
	Contains 0/3 valid signatures from the previous root
	root version 8, expires 2024/03/26

Verifying targets.json...
	Contains 0/3 valid signatures from the current staged metadata
	targets version 8, expires 2024/03/26
```

#### Release Note
N/A

#### Documentation
N/A
