### PR TITLE
Push new timestamp if > 2 days after signing

### DIFF
--- a/.github/workflows/stable-snapshot-timestamp.yml
+++ b/.github/workflows/stable-snapshot-timestamp.yml
@@ -76,9 +76,9 @@ jobs:
               echo "found ceremony branch $branch"
               branch_date=$(echo "${branch}" | cut -d '/' -f3)
               days_diff=$(( ($(date -d "00:00" +%s) - $(date -d "${branch_date}" +%s)) / (24*3600) ))
-              if [[ "$days_diff" -lt 5 ]]; then
-                # Detected ceremony within 5 days of current date
-                echo "detected ceremony branch $branch within 5 days, stopping automated cron"
+              if [[ "$days_diff" -lt 2 ]]; then
+                # Detected ceremony within 2 days of current date
+                echo "detected ceremony branch $branch within 2 days, stopping automated cron"
                 echo "block_snapshot=true" >> "${GITHUB_OUTPUT}"
               fi
             fi

--- a/.github/workflows/stable-timestamp.yml
+++ b/.github/workflows/stable-timestamp.yml
@@ -70,9 +70,9 @@ jobs:
               echo "found ceremony branch $branch"
               branch_date=$(echo "${branch}" | cut -d '/' -f3)
               days_diff=$(( ($(date -d "00:00" +%s) - $(date -d "${branch_date}" +%s)) / (24*3600) ))
-              if [[ "$days_diff" -lt 5 ]]; then
-                # Detected ceremony within 5 days of current date
-                echo "detected ceremony branch $branch within 5 days, stopping automated cron"
+              if [[ "$days_diff" -lt 2 ]]; then
+                # Detected ceremony within 2 days of current date
+                echo "detected ceremony branch $branch within 2 days, stopping automated cron"
                 echo "block_timestamp=true" >> "${GITHUB_OUTPUT}"
               fi
             fi


### PR DESCRIPTION
Fixes errors like https://sigstore.pagerduty.com/incidents/Q3GZN3SPEK8JTR 
The 5-day check no longer works well with the two-day timestamp.json expiration check and bots updating the timestamp twice a week.

See more:
- https://sigstore.slack.com/archives/C03R5G3CU2H/p1696191295010549
- https://docs.google.com/document/d/1XmIbW4W9osLvO5HBaC4O6Qoem5Hc0Pt9saa06qKs2a8/edit#heading=h.f8tupnubqa5q => Oct 1 incident description