### PR TITLE
add cache invalidation calls

### DIFF
--- a/.github/workflows/sync-ceremony-to-main.yml
+++ b/.github/workflows/sync-ceremony-to-main.yml
@@ -61,7 +61,7 @@ jobs:
           destination_branch: ${{ github.event.repository.default_branch }}
           pr_title: "Merge ceremony branch ${{ inputs.branch || github.ref_name }} into ${{ github.event.repository.default_branch }}"
           pr_body: "Merge ceremony branch to main"
-          pr_reviewer: asraa,dlorenc,haydentherapper,joshuagl,kommendorkapten
+          pr_reviewer: asraa,bobcallaway,haydentherapper,joshuagl,kommendorkapten
 
   sync:
     permissions:
@@ -125,6 +125,7 @@ jobs:
               gcloud --quiet storage rm gs://sigstore-preprod-tuf-root/$path
             fi;
           done
+          gcloud compute url-maps invalidate-cdn-cache tuf-preprod-repo-cdn-lb --path "/*" --async
 
   if-failed:
     runs-on: ubuntu-latest

--- a/.github/workflows/sync-main-to-preprod-and-prod.yml
+++ b/.github/workflows/sync-main-to-preprod-and-prod.yml
@@ -125,6 +125,8 @@ jobs:
 
           # NOTE as this workflow runs only when timestamp or snapshot files are added or updated, there should not
           # be a scenario where files that are removed from main must be synced to (removed from) preprod/prod.
+          gcloud compute url-maps invalidate-cdn-cache tuf-preprod-repo-cdn-lb --path "/*" --async
+          gcloud compute url-maps invalidate-cdn-cache tuf-repo-cdn-lb --path "/*" --async
 
   if-failed:
     runs-on: ubuntu-latest

--- a/.github/workflows/sync-main-to-staging.yml
+++ b/.github/workflows/sync-main-to-staging.yml
@@ -92,6 +92,8 @@ jobs:
               gcloud --quiet storage rm gs://tuf-root-staging/$path
             fi;
           done
+          # note this is in project projectsigstore-staging
+          gcloud compute url-maps invalidate-cdn-cache tuf-repo-cdn-lb --path "/*" --async
 
   if-failed:
     runs-on: ubuntu-latest

--- a/.github/workflows/sync-preprod-to-prod.yml
+++ b/.github/workflows/sync-preprod-to-prod.yml
@@ -63,6 +63,7 @@ jobs:
               gcloud --quiet storage rm gs://sigstore-tuf-root/$path
             fi;
           done
+          gcloud compute url-maps invalidate-cdn-cache tuf-repo-cdn-lb --path "/*" --async
 
   if-failed:
     runs-on: ubuntu-latest


### PR DESCRIPTION
When we push new content into the GCS bucket, we need to explicitly invalidate the CDN cache so that any subsequent calls to the CDN pull the most recent content.

Note that these commands append `--async`, which start the command but do not block on completion. Invalidation commands have been observed to take up to 10min to complete.