### PR TITLE
swap setup-gcloud and auth actions order

### DIFF
--- a/.github/workflows/initialize.yml
+++ b/.github/workflows/initialize.yml
@@ -81,9 +81,6 @@ jobs:
         with:
           go-version: '1.20'
           check-latest: true
-      - uses: google-github-actions/setup-gcloud@e30db14379863a8c79331b04a9969f4c1e225e0b # v1.1.1
-        with:
-          project_id: sigstore-root-signing
       # Setup OIDC->SA auth
       - uses: google-github-actions/auth@35b0e87d162680511bf346c299f71c9c5c379033 # v1.1.1
         id: auth
@@ -92,6 +89,9 @@ jobs:
           workload_identity_provider: 'projects/163070369698/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider'
           service_account: 'github-actions@sigstore-root-signing.iam.gserviceaccount.com'
           create_credentials_file: true
+      - uses: google-github-actions/setup-gcloud@e30db14379863a8c79331b04a9969f4c1e225e0b # v1.1.1
+        with:
+          project_id: sigstore-root-signing
       - name: Login
         run: |
           gcloud auth login --brief --cred-file="${{ steps.auth.outputs.credentials_file_path }}"

--- a/.github/workflows/reuseable-snapshot-timestamp.yml
+++ b/.github/workflows/reuseable-snapshot-timestamp.yml
@@ -90,9 +90,6 @@ jobs:
         with:
           go-version: '1.20'
           check-latest: true
-      - uses: google-github-actions/setup-gcloud@e30db14379863a8c79331b04a9969f4c1e225e0b # v1.1.1
-        with:
-          project_id: sigstore-root-signing
       # Setup OIDC->SA auth
       - uses: google-github-actions/auth@35b0e87d162680511bf346c299f71c9c5c379033 # v1.1.1
         id: auth
@@ -101,6 +98,9 @@ jobs:
           workload_identity_provider: ${{ inputs.provider }}
           service_account: ${{ inputs.service_account }}
           create_credentials_file: true
+      - uses: google-github-actions/setup-gcloud@e30db14379863a8c79331b04a9969f4c1e225e0b # v1.1.1
+        with:
+          project_id: sigstore-root-signing
       - name: Login
         run: |
           gcloud auth login --brief --cred-file="${{ steps.auth.outputs.credentials_file_path }}"

--- a/.github/workflows/sync-ceremony-to-main.yml
+++ b/.github/workflows/sync-ceremony-to-main.yml
@@ -75,9 +75,6 @@ jobs:
         with:
           go-version: '1.20'
           check-latest: true
-      - uses: google-github-actions/setup-gcloud@e30db14379863a8c79331b04a9969f4c1e225e0b # v1.1.1
-        with:
-          project_id: project-rekor
       # Setup OIDC->SA auth
       - uses: google-github-actions/auth@35b0e87d162680511bf346c299f71c9c5c379033 # v1.1.1
         id: auth
@@ -86,6 +83,9 @@ jobs:
           workload_identity_provider: 'projects/237800849078/locations/global/workloadIdentityPools/root-signing-pool/providers/sigstore-root'
           service_account: 'sigstore-root-signing@project-rekor.iam.gserviceaccount.com'
           create_credentials_file: true
+      - uses: google-github-actions/setup-gcloud@e30db14379863a8c79331b04a9969f4c1e225e0b # v1.1.1
+        with:
+          project_id: project-rekor
       - name: Login
         run: |
           gcloud auth login --brief --cred-file="${{ steps.auth.outputs.credentials_file_path }}"

--- a/.github/workflows/sync-main-to-preprod-and-prod.yml
+++ b/.github/workflows/sync-main-to-preprod-and-prod.yml
@@ -49,9 +49,6 @@ jobs:
         with:
           go-version: '1.20'
           check-latest: true
-      - uses: google-github-actions/setup-gcloud@e30db14379863a8c79331b04a9969f4c1e225e0b # v1.1.1
-        with:
-          project_id: project-rekor
       # Setup OIDC->SA auth
       - uses: google-github-actions/auth@35b0e87d162680511bf346c299f71c9c5c379033 # v1.1.1
         id: auth
@@ -60,6 +57,9 @@ jobs:
           workload_identity_provider: 'projects/237800849078/locations/global/workloadIdentityPools/root-signing-pool/providers/sigstore-root'
           service_account: 'sigstore-root-signing@project-rekor.iam.gserviceaccount.com'
           create_credentials_file: true
+      - uses: google-github-actions/setup-gcloud@e30db14379863a8c79331b04a9969f4c1e225e0b # v1.1.1
+        with:
+          project_id: project-rekor
       - name: Login
         run: |
           gcloud auth login --brief --cred-file="${{ steps.auth.outputs.credentials_file_path }}"

--- a/.github/workflows/sync-preprod-to-prod.yml
+++ b/.github/workflows/sync-preprod-to-prod.yml
@@ -25,9 +25,6 @@ jobs:
     permissions:
       id-token: 'write'
     steps:
-      - uses: google-github-actions/setup-gcloud@e30db14379863a8c79331b04a9969f4c1e225e0b # v1.1.1
-        with:
-          project_id: project-rekor
       # Setup OIDC->SA auth
       - uses: google-github-actions/auth@35b0e87d162680511bf346c299f71c9c5c379033 # v1.1.1
         id: auth
@@ -36,6 +33,9 @@ jobs:
           workload_identity_provider: 'projects/237800849078/locations/global/workloadIdentityPools/root-signing-pool/providers/sigstore-root'
           service_account: 'sigstore-root-signing@project-rekor.iam.gserviceaccount.com'
           create_credentials_file: true
+      - uses: google-github-actions/setup-gcloud@e30db14379863a8c79331b04a9969f4c1e225e0b # v1.1.1
+        with:
+          project_id: project-rekor
       - name: login
         run: |
           gcloud auth login --brief --cred-file="${{ steps.auth.outputs.credentials_file_path }}"


### PR DESCRIPTION
> Warning: No authentication found for gcloud, authenticate with `google-github-actions/auth`.

^^ is printed during many of the GHA runs because gcloud tries to infer authentication ahead of the auth action running. This ensures gcloud is setup after auth, to squelch this error.