### PR TITLE
workflows: Replace create-issue with other actions

### DIFF
--- a/.github/workflows/reuseable-snapshot-timestamp.yml
+++ b/.github/workflows/reuseable-snapshot-timestamp.yml
@@ -151,32 +151,24 @@ jobs:
     needs: [snapshot_and_timestamp]
     permissions:
       issues: 'write'
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      ISSUE_REPOSITORY: sigstore/root-signing
+      actions: 'read'
     if: always() && needs.snapshot_and_timestamp.result == 'failure'
     steps:
-      - name: Create issue on failure
-        uses: sigstore/sigstore-probers/.github/actions/create-issue@main
+      - name: Open issue or add comment on failure
+        uses: sigstore/sigstore-probers/.github/actions/open-workflow-issue@main
         with:
-          issue_repository: sigstore/root-signing
-          issue_type: FAILURE
+          comment_for_each_failure: true
 
   if-pass:
     runs-on: ubuntu-latest
     needs: [snapshot_and_timestamp]
     permissions:
       issues: 'write'
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      ISSUE_REPOSITORY: sigstore/root-signing
+      actions: 'read'
     if: always() && needs.snapshot_and_timestamp.result == 'success'
     steps:
-      - name: Create issue on failure
-        uses: sigstore/sigstore-probers/.github/actions/create-issue@main
-        with:
-          issue_repository: sigstore/root-signing
-          issue_type: SUCCESS
+      - name: Close issue if one is open
+        uses: sigstore/sigstore-probers/.github/actions/close-workflow-issue@main
 
   push:
     needs: snapshot_and_timestamp
@@ -227,29 +219,21 @@ jobs:
     needs: [push]
     permissions:
       issues: 'write'
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      ISSUE_REPOSITORY: sigstore/root-signing
+      actions: 'read'
     if: always() && needs.push.result == 'failure'
     steps:
-      - name: Create issue on failure
-        uses: sigstore/sigstore-probers/.github/actions/create-issue@main
+      - name: Open issue or add comment on failure
+        uses: sigstore/sigstore-probers/.github/actions/open-workflow-issue@main
         with:
-          issue_repository: sigstore/root-signing
-          issue_type: FAILURE
+          comment_for_each_failure: true
 
   if-push-pass:
     runs-on: ubuntu-latest
     needs: [push]
     permissions:
       issues: 'write'
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      ISSUE_REPOSITORY: sigstore/root-signing
+      actions: 'read'
     if: always() && needs.push.result == 'success'
     steps:
-      - name: Create issue on failure
-        uses: sigstore/sigstore-probers/.github/actions/create-issue@main
-        with:
-          issue_repository: sigstore/root-signing
-          issue_type: SUCCESS
+      - name: Close issue if one is open
+        uses: sigstore/sigstore-probers/.github/actions/close-workflow-issue@main

--- a/.github/workflows/sync-ceremony-to-main.yml
+++ b/.github/workflows/sync-ceremony-to-main.yml
@@ -132,13 +132,10 @@ jobs:
     needs: [sync]
     permissions:
       issues: 'write'
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      ISSUE_REPOSITORY: sigstore/root-signing
+      actions: 'read'
     if: always() && needs.sync.result == 'failure'
     steps:
-      - name: Create issue on failure
-        uses: sigstore/sigstore-probers/.github/actions/create-issue@main
+      - name: Open issue or add comment on failure
+        uses: sigstore/sigstore-probers/.github/actions/open-workflow-issue@main
         with:
-          issue_repository: sigstore/root-signing
-          issue_type: FAILURE
+          comment_for_each_failure: true

--- a/.github/workflows/sync-main-to-preprod-and-prod.yml
+++ b/.github/workflows/sync-main-to-preprod-and-prod.yml
@@ -133,13 +133,10 @@ jobs:
     needs: [sync]
     permissions:
       issues: 'write'
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      ISSUE_REPOSITORY: sigstore/root-signing
+      actions: 'read'
     if: always() && needs.sync.result == 'failure'
     steps:
-      - name: Create issue on failure
-        uses: sigstore/sigstore-probers/.github/actions/create-issue@main
+      - name: Open issue or add comment on failure
+        uses: sigstore/sigstore-probers/.github/actions/open-workflow-issue@main
         with:
-          issue_repository: sigstore/root-signing
-          issue_type: FAILURE
+          comment_for_each_failure: true

--- a/.github/workflows/sync-main-to-staging.yml
+++ b/.github/workflows/sync-main-to-staging.yml
@@ -100,13 +100,10 @@ jobs:
     needs: [sync]
     permissions:
       issues: 'write'
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      ISSUE_REPOSITORY: sigstore/root-signing
+      actions: 'read'
     if: always() && needs.sync.result == 'failure'
     steps:
-      - name: Create issue on failure
-        uses: sigstore/sigstore-probers/.github/actions/create-issue@main
+      - name: Open issue or add comment on failure
+        uses: sigstore/sigstore-probers/.github/actions/open-workflow-issue@main
         with:
-          issue_repository: sigstore/root-signing
-          issue_type: FAILURE
+          comment_for_each_failure: true

--- a/.github/workflows/sync-preprod-to-prod.yml
+++ b/.github/workflows/sync-preprod-to-prod.yml
@@ -70,13 +70,10 @@ jobs:
     needs: [sync]
     permissions:
       issues: 'write'
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      ISSUE_REPOSITORY: sigstore/root-signing
+      actions: 'read'
     if: always() && needs.sync.result == 'failure'
     steps:
-      - name: Create issue on failure
-        uses: sigstore/sigstore-probers/.github/actions/create-issue@main
+      - name: Open issue or add comment on failure
+        uses: sigstore/sigstore-probers/.github/actions/open-workflow-issue@main
         with:
-          issue_repository: sigstore/root-signing
-          issue_type: FAILURE
+          comment_for_each_failure: true


### PR DESCRIPTION
create-issue had problems with private repos and I decided to rewrite as it seemed quite fragile. This PR changes root-signing to these new actions as well.

This does not fix any immediate issues in root-signing but the new actions should be more maintainable and robust. If this is merged I intend to remove create-issue action completely.

* The produced comment is not 1:1 identical but very close: https://github.com/jku/create-issue-tester/issues/17
* Functionality in root-signing should not change in any way
* The `actions: 'read'` lines included in this commit are not really required in this repository, they are only informational

Fixes #1082