### PR TITLE
Allow multi line script

### DIFF
--- a/.github/workflows/reuseable-snapshot-timestamp.yml
+++ b/.github/workflows/reuseable-snapshot-timestamp.yml
@@ -191,14 +191,14 @@ jobs:
       # Open pull request changes
       - name: create pull request for no snapshot
         if: ${{ inputs.disable_snapshot }}
-        run:
+        run: |
           git commit -s --allow-empty -m "Update timestamp"
           git push origin update-snapshot-timestamp
           GH_TOKEN=${{ secrets.token || secrets.GITHUB_TOKEN }} gh pr create -B ${{ inputs.branch }} -H update-snapshot-timestamp -t "Update Timestamp" -b "Sign timestamp file" -r bobcallaway -r haydentherapper -r kommendorkapten
 
       - name: create pull request for timestamp/snapshot
         if: ${{ !inputs.disable_snapshot }}
-        run:
+        run: |
           git commit -s --allow-empty -m "Update snapshot and timestamp"
           git push origin update-snapshot-timestamp
           GH_TOKEN=${{ secrets.token || secrets.GITHUB_TOKEN }} gh pr create -B ${{ inputs.branch }} -H update-snapshot-timestamp -t "Update Snapshot and Timestamp" -b "Sign snapshot and timestamp files" -r bobcallaway -r haydentherapper -r kommendorkapten


### PR DESCRIPTION
Missing the "|" to execute a multi-line script

Fixes https://github.com/sigstore/root-signing/issues/1101

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
