### PR TITLE
Change GCP service account used to manage prod GCS bucket

### DIFF
--- a/.github/workflows/initialize.yml
+++ b/.github/workflows/initialize.yml
@@ -81,7 +81,7 @@ jobs:
         with:
           go-version-file: './go.mod'
           check-latest: true
-      # Setup OIDC->SA auth
+      # Setup OIDC->SA auth for signing with KMS
       - uses: google-github-actions/auth@5a50e581162a13f4baa8916d01180d2acbc04363 # v2.1.0
         id: auth
         with:

--- a/.github/workflows/reuseable-snapshot-timestamp.yml
+++ b/.github/workflows/reuseable-snapshot-timestamp.yml
@@ -100,6 +100,7 @@ jobs:
           create_credentials_file: true
       - uses: google-github-actions/setup-gcloud@98ddc00a17442e89a24bbf282954a3b65ce6d200 # v2.1.0
         with:
+          # Note: This needs to be parameterized if the KMS keys are in a different project
           project_id: sigstore-root-signing
       - name: Login
         run: |

--- a/.github/workflows/sync-ceremony-to-main.yml
+++ b/.github/workflows/sync-ceremony-to-main.yml
@@ -80,8 +80,8 @@ jobs:
         id: auth
         with:
           token_format: 'access_token'
-          workload_identity_provider: 'projects/237800849078/locations/global/workloadIdentityPools/root-signing-pool/providers/sigstore-root'
-          service_account: 'sigstore-root-signing@project-rekor.iam.gserviceaccount.com'
+          workload_identity_provider: 'projects/306323169285/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider'
+          service_account: 'tuf-gha@project-rekor.iam.gserviceaccount.com'
           create_credentials_file: true
       - uses: google-github-actions/setup-gcloud@98ddc00a17442e89a24bbf282954a3b65ce6d200 # v2.1.0
         with:

--- a/.github/workflows/sync-main-to-preprod-and-prod.yml
+++ b/.github/workflows/sync-main-to-preprod-and-prod.yml
@@ -54,8 +54,8 @@ jobs:
         id: auth
         with:
           token_format: 'access_token'
-          workload_identity_provider: 'projects/237800849078/locations/global/workloadIdentityPools/root-signing-pool/providers/sigstore-root'
-          service_account: 'sigstore-root-signing@project-rekor.iam.gserviceaccount.com'
+          workload_identity_provider: 'projects/306323169285/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider'
+          service_account: 'tuf-gha@project-rekor.iam.gserviceaccount.com'
           create_credentials_file: true
       - uses: google-github-actions/setup-gcloud@98ddc00a17442e89a24bbf282954a3b65ce6d200 # v2.1.0
         with:

--- a/.github/workflows/sync-main-to-staging.yml
+++ b/.github/workflows/sync-main-to-staging.yml
@@ -37,7 +37,8 @@ jobs:
         with:
           go-version-file: './go.mod'
           check-latest: true
-      # Setup OIDC->SA auth
+      # Setup OIDC->SA auth for managing GCS bucket
+      # Will be replaced with sigstore/root-signing-staging in the near future
       - uses: google-github-actions/auth@5a50e581162a13f4baa8916d01180d2acbc04363 # v2.1.0
         id: auth
         with:

--- a/.github/workflows/sync-preprod-to-prod.yml
+++ b/.github/workflows/sync-preprod-to-prod.yml
@@ -30,8 +30,8 @@ jobs:
         id: auth
         with:
           token_format: 'access_token'
-          workload_identity_provider: 'projects/237800849078/locations/global/workloadIdentityPools/root-signing-pool/providers/sigstore-root'
-          service_account: 'sigstore-root-signing@project-rekor.iam.gserviceaccount.com'
+          workload_identity_provider: 'projects/306323169285/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider'
+          service_account: 'tuf-gha@project-rekor.iam.gserviceaccount.com'
           create_credentials_file: true
       - uses: google-github-actions/setup-gcloud@98ddc00a17442e89a24bbf282954a3b65ce6d200 # v2.1.0
         with:


### PR DESCRIPTION
This new account has the minimum set of roles needed to manage the GCS bucket and invalidate the CDN cache. It also manages a new KMS signing key, but that is not currently referenced in this repo.

Staging uses the same github-actions@ service account. This will be changed once we use sigstore/root-signing-staging to manage the TUF repository for staging.

Prod still uses an SA under the sigstore-root-signing GCP project, which houses the production KMS keys.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
