### PR TITLE
Git add before commit

### DIFF
--- a/.github/workflows/reuseable-snapshot-timestamp.yml
+++ b/.github/workflows/reuseable-snapshot-timestamp.yml
@@ -187,26 +187,25 @@ jobs:
           name: snapshot-timestamp
           path: snapshot-timestamp
       - run: |
+          git checkout -b update-snapshot-timestamp
           git apply --verbose snapshot-timestamp/*
           rm -r snapshot-timestamp
+          git add ${{ inputs.repo }}
+          git config --global user.email "noreply@github.com"
+          git config --global user.name "GitHub"
+
       # Open pull request changes
       - name: create pull request for no snapshot
         if: ${{ inputs.disable_snapshot }}
         run: |
-          git config --global user.email "noreply@github.com"
-          git config --global user.name "GitHub"
-          git checkout -b update-snapshot-timestamp
-          git commit -s -a -m "Update timestamp"
+          git commit -s -m "Update timestamp"
           git push origin update-snapshot-timestamp
           GH_TOKEN=${{ secrets.token || secrets.GITHUB_TOKEN }} gh pr create -B ${{ inputs.branch }} -H update-snapshot-timestamp -t "Update Timestamp" -b "Sign timestamp file" -r bobcallaway -r haydentherapper -r kommendorkapten
 
       - name: create pull request for timestamp/snapshot
         if: ${{ !inputs.disable_snapshot }}
         run: |
-          git config --global user.email "noreply@github.com"
-          git config --global user.name "GitHub"
-          git checkout -b update-snapshot-timestamp
-          git commit -s -a -m "Update snapshot and timestamp"
+          git commit -s  -m "Update snapshot and timestamp"
           git push origin update-snapshot-timestamp
           GH_TOKEN=${{ secrets.token || secrets.GITHUB_TOKEN }} gh pr create -B ${{ inputs.branch }} -H update-snapshot-timestamp -t "Update Snapshot and Timestamp" -b "Sign snapshot and timestamp files" -r bobcallaway -r haydentherapper -r kommendorkapten
 


### PR DESCRIPTION
#### Summary
Fixes missing versioned snapshot file, see https://github.com/sigstore/root-signing/pull/1115
I believe the issue was that no `git add` was performed, but `git commit` was executed with `-a` flag, which only adds staged file, not files unknown go git (such as the new versioned file).

This PR also shuffles some commands around so they can be reused.

#### Release Note
N/A

#### Documentation
N/A
