### PR TITLE
Keytype upgrade

### DIFF
--- a/cmd/tuf/app/add-delegation.go
+++ b/cmd/tuf/app/add-delegation.go
@@ -140,7 +140,9 @@ func DelegationCmd(ctx context.Context, opts *DelegationOptions) error {
 		if err != nil {
 			return err
 		}
-		tufKey, err := pkeys.ConstructTufKeyFromPublic(ctx, publicKey)
+		// When adding the delegation we don't need to carry over the
+		// older deprecated format.
+		tufKey, err := pkeys.ConstructTufKeyFromPublic(ctx, publicKey, false)
 		if err != nil {
 			return err
 		}

--- a/cmd/tuf/app/init.go
+++ b/cmd/tuf/app/init.go
@@ -180,7 +180,8 @@ func InitCmd(ctx context.Context, directory string,
 		}
 
 		// Construct TUF key.
-		tufKey, err := pkeys.ConstructTufKey(ctx, signer)
+		// Only create keys using the current key type
+		tufKey, err := pkeys.ConstructTufKey(ctx, signer, false)
 		if err != nil {
 			return err
 		}
@@ -341,7 +342,8 @@ func getKeysFromDir(dir string) ([]*data.PublicKey, error) {
 			if err != nil {
 				return nil, err
 			}
-			tufKey, err := pkeys.EcdsaTufKey(key.PublicKey)
+			// Only add keys with the new format
+			tufKey, err := pkeys.EcdsaTufKey(key.PublicKey, false)
 			if err != nil {
 				return nil, err
 			}

--- a/cmd/verify/app/keys.go
+++ b/cmd/verify/app/keys.go
@@ -85,7 +85,7 @@ func verifySigningKeys(dirname string, rootCA *x509.Certificate) (*KeyMap, error
 
 			log.Printf("\nVERIFIED KEY WITH SERIAL NUMBER %d\n", key.SerialNumber)
 			log.Printf("TUF key ids: \n")
-			for kid, _ := range keyMap {
+			for kid := range keyMap {
 				log.Printf("\t%s ", kid)
 			}
 		}

--- a/cmd/verify/app/keys.go
+++ b/cmd/verify/app/keys.go
@@ -71,18 +71,23 @@ func verifySigningKeys(dirname string, rootCA *x509.Certificate) (*KeyMap, error
 				log.Printf("error verifying key %d: %s", key.SerialNumber, err)
 				return nil, err
 			}
-			tufKey, err := keys.EcdsaTufKey(key.PublicKey)
-			if err != nil {
-				return nil, err
+
+			for _, bv := range []bool{true, false} {
+				tufKey, err := keys.EcdsaTufKey(key.PublicKey, bv)
+				if err != nil {
+					return nil, err
+				}
+				if len(tufKey.IDs()) == 0 {
+					return nil, errors.New("error getting key ID")
+				}
+				keyMap[tufKey.IDs()[0]] = key
 			}
-			if len(tufKey.IDs()) == 0 {
-				return nil, errors.New("error getting key ID")
-			}
-			keyMap[tufKey.IDs()[0]] = key
 
 			log.Printf("\nVERIFIED KEY WITH SERIAL NUMBER %d\n", key.SerialNumber)
 			log.Printf("TUF key ids: \n")
-			log.Printf("\t%s ", tufKey.IDs()[0])
+			for kid, _ := range keyMap {
+				log.Printf("\t%s ", kid)
+			}
 		}
 	}
 	// Note we use relative path here to simplify things.

--- a/pkg/keys/keys_test.go
+++ b/pkg/keys/keys_test.go
@@ -160,7 +160,7 @@ func TestToSigningKey(t *testing.T) {
 				t.Errorf("unexpected error generating signing key (%s): %s", tt.name, err)
 			}
 			if tt.expectSuccess {
-				pemPubKey, err := EcdsaTufKey(key.PublicKey)
+				pemPubKey, err := EcdsaTufKey(key.PublicKey, true)
 				if err != nil {
 					t.Errorf("unexpected error generating PEM TUF public key: %s", err)
 				}
@@ -184,7 +184,7 @@ func TestGetSigningKey(t *testing.T) {
 	}
 
 	t.Run("valid signing key with PEM", func(t *testing.T) {
-		signingKeyPem, err := ConstructTufKey(ctx, signingKey)
+		signingKeyPem, err := ConstructTufKey(ctx, signingKey, true)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/scripts/step-2.sh
+++ b/scripts/step-2.sh
@@ -38,7 +38,7 @@ checkout_branch
 read -n1 -r -s -p "Insert your Yubikey, then press any key to continue...\n"
 
 # Sign the root and targets with hardware key
-./tuf sign -repository "$REPO" -roles root -roles targets -sk
+./tuf sign -repository "$REPO" -roles root -roles targets -sk -add-old-type true
 
 # Ask user to remove key (and replace with SSH security key)
 read -n1 -r -s -p "Remove your Yubikey, then press any key to continue...\n"

--- a/scripts/step-3.sh
+++ b/scripts/step-3.sh
@@ -47,11 +47,11 @@ checkout_branch
 # Skip if only timestamping
 if [ -z "$DISABLE_SNAPSHOT" ]; then
     ./tuf snapshot -repository "$REPO"
-    ./tuf sign -repository "$REPO" -roles snapshot -key "${SNAPSHOT_KEY}" --add-old-type
+    ./tuf sign -repository "$REPO" -roles snapshot -key "${SNAPSHOT_KEY}" --add-old-type true
 fi
 
 # Timestamp and sign the timestamp with timestamp kms key
 ./tuf timestamp -repository "$REPO"
-./tuf sign -repository "$REPO" -roles timestamp -key "${TIMESTAMP_KEY}" --add-old-type
+./tuf sign -repository "$REPO" -roles timestamp -key "${TIMESTAMP_KEY}" --add-old-type true
 
 commit_and_push_changes snapshot-timestamp

--- a/scripts/step-3.sh
+++ b/scripts/step-3.sh
@@ -47,11 +47,11 @@ checkout_branch
 # Skip if only timestamping
 if [ -z "$DISABLE_SNAPSHOT" ]; then
     ./tuf snapshot -repository "$REPO"
-    ./tuf sign -repository "$REPO" -roles snapshot -key "${SNAPSHOT_KEY}"
+    ./tuf sign -repository "$REPO" -roles snapshot -key "${SNAPSHOT_KEY}" --add-old-type
 fi
 
 # Timestamp and sign the timestamp with timestamp kms key
 ./tuf timestamp -repository "$REPO"
-./tuf sign -repository "$REPO" -roles timestamp -key "${TIMESTAMP_KEY}"
+./tuf sign -repository "$REPO" -roles timestamp -key "${TIMESTAMP_KEY}" --add-old-type
 
 commit_and_push_changes snapshot-timestamp

--- a/scripts/step-3.sh
+++ b/scripts/step-3.sh
@@ -47,11 +47,11 @@ checkout_branch
 # Skip if only timestamping
 if [ -z "$DISABLE_SNAPSHOT" ]; then
     ./tuf snapshot -repository "$REPO"
-    ./tuf sign -repository "$REPO" -roles snapshot -key "${SNAPSHOT_KEY}" --add-old-type true
+    ./tuf sign -repository "$REPO" -roles snapshot -key "${SNAPSHOT_KEY}" -add-old-type true
 fi
 
 # Timestamp and sign the timestamp with timestamp kms key
 ./tuf timestamp -repository "$REPO"
-./tuf sign -repository "$REPO" -roles timestamp -key "${TIMESTAMP_KEY}" --add-old-type true
+./tuf sign -repository "$REPO" -roles timestamp -key "${TIMESTAMP_KEY}" -add-old-type true
 
 commit_and_push_changes snapshot-timestamp

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -188,11 +188,11 @@ func TestSignRootTargets(t *testing.T) {
 	// Sign root and targets.
 	rootSigner := stack.getSigner(t, rootKeyRef)
 	if err := app.SignCmd(ctx, stack.repoDir, []string{"root", "targets"},
-		rootSigner, false); err != nil {
+		rootSigner, false, false); err != nil {
 		t.Fatal(err)
 	}
 
-	pubKey, err := keys.ConstructTufKey(ctx, rootSigner)
+	pubKey, err := keys.ConstructTufKey(ctx, rootSigner, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -252,7 +252,7 @@ func TestSnapshotUnvalidatedFails(t *testing.T) {
 	// Now sign root and targets with 1/1 threshold key.
 	rootSigner := stack.getSigner(t, rootKeyRef)
 	if err := app.SignCmd(ctx, stack.repoDir, []string{"root", "targets"},
-		rootSigner, false); err != nil {
+		rootSigner, false, false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -301,7 +301,7 @@ func TestPublishSuccess(t *testing.T) {
 	// Sign root & targets
 	rootSigner := stack.getSigner(t, rootKeyRef)
 	if err := app.SignCmd(ctx, stack.repoDir, []string{"root", "targets"},
-		rootSigner, false); err != nil {
+		rootSigner, false, false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -359,10 +359,10 @@ func TestRotateRootKey(t *testing.T) {
 	// Sign root & targets with key 1
 	rootSigner1 := stack.getSigner(t, rootKeyRef1)
 	if err := app.SignCmd(ctx, stack.repoDir, []string{"root", "targets"},
-		rootSigner1, false); err != nil {
+		rootSigner1, false, false); err != nil {
 		t.Fatal(err)
 	}
-	rootTufKey1, err := keys.ConstructTufKey(ctx, rootSigner1)
+	rootTufKey1, err := keys.ConstructTufKey(ctx, rootSigner1, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -383,7 +383,7 @@ func TestRotateRootKey(t *testing.T) {
 		t.Fatalf("expected root role")
 	}
 	rootSigner2 := stack.getSigner(t, rootKeyRef2)
-	rootTufKey2, err := keys.ConstructTufKey(ctx, rootSigner2)
+	rootTufKey2, err := keys.ConstructTufKey(ctx, rootSigner2, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -415,7 +415,7 @@ func TestRotateRootKey(t *testing.T) {
 		t.Fatalf("expected root role")
 	}
 	rootSigner3 := stack.getSigner(t, rootKeyRef3)
-	rootTufKey3, err := keys.ConstructTufKey(ctx, rootSigner3)
+	rootTufKey3, err := keys.ConstructTufKey(ctx, rootSigner3, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -434,7 +434,7 @@ func TestRotateRootKey(t *testing.T) {
 
 	// Sign root & targets
 	if err := app.SignCmd(ctx, stack.repoDir, []string{"root", "targets"}, rootSigner1,
-		false); err != nil {
+		false, false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -465,7 +465,7 @@ func TestRotateTarget(t *testing.T) {
 	// Sign root & targets
 	rootSigner := stack.getSigner(t, rootKeyRef)
 	if err := app.SignCmd(ctx, stack.repoDir, []string{"root", "targets"},
-		rootSigner, false); err != nil {
+		rootSigner, false, false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -505,7 +505,7 @@ func TestRotateTarget(t *testing.T) {
 
 	// Sign root & targets
 	if err := app.SignCmd(ctx, stack.repoDir, []string{"root", "targets"},
-		rootSigner, false); err != nil {
+		rootSigner, false, false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -552,7 +552,7 @@ func TestConsistentSnapshotFlip(t *testing.T) {
 	// Sign root & targets
 	rootSigner := stack.getSigner(t, rootKeyRef)
 	if err := app.SignCmd(ctx, stack.repoDir, []string{"root", "targets"},
-		rootSigner, false); err != nil {
+		rootSigner, false, false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -590,7 +590,7 @@ func TestConsistentSnapshotFlip(t *testing.T) {
 
 	// Sign root & targets
 	if err := app.SignCmd(ctx, stack.repoDir, []string{"root", "targets"},
-		rootSigner, false); err != nil {
+		rootSigner, false, false); err != nil {
 		t.Fatal(err)
 	}
 	// Sign snapshot and timestamp
@@ -651,7 +651,7 @@ func TestSnapshotKeyRotate(t *testing.T) {
 	// Sign root & targets with key 1
 	rootSigner := stack.getSigner(t, rootKeyRef)
 	if err := app.SignCmd(ctx, stack.repoDir, []string{"root", "targets"},
-		rootSigner, false); err != nil {
+		rootSigner, false, false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -671,7 +671,7 @@ func TestSnapshotKeyRotate(t *testing.T) {
 		t.Fatalf("expected snapshot role")
 	}
 	snapshotSigner1 := stack.getSigner(t, stack.snapshotRef)
-	snapshotTufKey1, err := keys.ConstructTufKey(ctx, snapshotSigner1)
+	snapshotTufKey1, err := keys.ConstructTufKey(ctx, snapshotSigner1, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -693,7 +693,7 @@ func TestSnapshotKeyRotate(t *testing.T) {
 
 	// Sign root & targets with key 1
 	if err := app.SignCmd(ctx, stack.repoDir, []string{"root", "targets"},
-		rootSigner, false); err != nil {
+		rootSigner, false, false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -712,7 +712,7 @@ func TestSnapshotKeyRotate(t *testing.T) {
 		t.Fatalf("expected snapshot role")
 	}
 	snapshotSigner2 := stack.getSigner(t, stack.snapshotRef)
-	snapshotTufKey2, err := keys.ConstructTufKey(ctx, snapshotSigner2)
+	snapshotTufKey2, err := keys.ConstructTufKey(ctx, snapshotSigner2, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -752,7 +752,7 @@ func TestProdTargetsConfig(t *testing.T) {
 	// Sign root & targets
 	rootSigner := stack.getSigner(t, rootKeyRef)
 	if err := app.SignCmd(ctx, stack.repoDir, []string{"root", "targets"},
-		rootSigner, false); err != nil {
+		rootSigner, false, false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -820,7 +820,7 @@ func TestDelegationsClearedOnInit(t *testing.T) {
 	// Sign root & targets with key 1
 	rootSigner := stack.getSigner(t, rootKeyRef)
 	if err := app.SignCmd(ctx, stack.repoDir, []string{"root", "targets"},
-		rootSigner, false); err != nil {
+		rootSigner, false, false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -870,13 +870,13 @@ func TestSignWithVersionBump(t *testing.T) {
 	// Sign root & targets with key 1
 	rootSigner := stack.getSigner(t, rootKeyRef)
 	if err := app.SignCmd(ctx, stack.repoDir, []string{"root", "targets"},
-		rootSigner, false); err != nil {
+		rootSigner, false, false); err != nil {
 		t.Fatal(err)
 	}
 	// Sign delegation
 	dSigner := stack.getSigner(t, delegationKeyRef)
 	if err := app.SignCmd(ctx, stack.repoDir, []string{"delegation"},
-		dSigner, false); err != nil {
+		dSigner, false, false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -892,7 +892,7 @@ func TestSignWithVersionBump(t *testing.T) {
 
 	// Increment the delegation metadata
 	if err := app.SignCmd(ctx, stack.repoDir, []string{"delegation"},
-		dSigner, true); err != nil {
+		dSigner, true, false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -975,10 +975,10 @@ func TestRotateRootKeyTwiceAfter(t *testing.T) {
 	// Sign root & targets with key 1
 	rootSigner1 := stack.getSigner(t, rootKeyRef1)
 	if err := app.SignCmd(ctx, stack.repoDir, []string{"root", "targets"},
-		rootSigner1, false); err != nil {
+		rootSigner1, false, false); err != nil {
 		t.Fatal(err)
 	}
-	pubKey1, err := keys.ConstructTufKey(ctx, rootSigner1)
+	pubKey1, err := keys.ConstructTufKey(ctx, rootSigner1, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1007,7 +1007,7 @@ func TestRotateRootKeyTwiceAfter(t *testing.T) {
 	}
 	// Sign root & targets
 	if err := app.SignCmd(ctx, stack.repoDir, []string{"root", "targets"}, rootSigner1,
-		false); err != nil {
+		false, false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1066,11 +1066,11 @@ func TestGetPublicKeyFromRepo(t *testing.T) {
 	// Sign root & targets with key
 	rootSigner := stack.getSigner(t, rootKeyRef)
 	if err := app.SignCmd(ctx, stack.repoDir, []string{"root", "targets"},
-		rootSigner, false); err != nil {
+		rootSigner, false, false); err != nil {
 		t.Fatal(err)
 	}
 
-	cosignKeyID := "314ae73abd3012fc73bfcc3783e31d03852716597642b891d6a33155c4baf600"
+	cosignKeyID := "8679120321f0dda9e41c5de3c68e913d383bc51266691007b7b4b7f99868ee6f"
 	keyID, err := app.GetKeyIDForRole(stack.repoDir, "delegation")
 	if err != nil {
 		t.Fatal(err)
@@ -1155,13 +1155,13 @@ func TestDelegationNullCustomMetadata(t *testing.T) {
 	// Sign root & targets with key 1
 	rootSigner := stack.getSigner(t, rootKeyRef)
 	if err := app.SignCmd(ctx, stack.repoDir, []string{"root", "targets"},
-		rootSigner, false); err != nil {
+		rootSigner, false, false); err != nil {
 		t.Fatal(err)
 	}
 	// Sign delegation
 	dSigner := stack.getSigner(t, delegationKeyRef)
 	if err := app.SignCmd(ctx, stack.repoDir, []string{"path"},
-		dSigner, false); err != nil {
+		dSigner, false, false); err != nil {
 		t.Fatal(err)
 	}
 

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -145,7 +145,7 @@ func (s *repoTestStack) snapshot(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := app.SignCmd(s.ctx, s.repoDir, []string{"snapshot"}, snapshotSigner, false); err != nil {
+	if err := app.SignCmd(s.ctx, s.repoDir, []string{"snapshot"}, snapshotSigner, false, true); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -158,7 +158,7 @@ func (s *repoTestStack) timestamp(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := app.SignCmd(s.ctx, s.repoDir, []string{"timestamp"}, timestampSigner, false); err != nil {
+	if err := app.SignCmd(s.ctx, s.repoDir, []string{"timestamp"}, timestampSigner, false, true); err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
#### Summary
This is the same as #1130 except that when signing timestamp and snapshot, use flag `add-old-type` as done in `step-2.sh`

#### Release Note
N/A

#### Documentation
N/A
