### PR TITLE
added signed npm delegation

### DIFF
--- a/repository/staged/registry.npmjs.org.json
+++ b/repository/staged/registry.npmjs.org.json
@@ -1,0 +1,27 @@
+{
+	"signed": {
+		"_type": "targets",
+		"spec_version": "1.0",
+		"version": 3,
+		"expires": "2024-09-12T06:13:15Z",
+		"targets": {
+			"registry.npmjs.org/keys.json": {
+				"length": 1017,
+				"hashes": {
+					"sha256": "7a8ec9678ad824cdccaa7a6dc0961caf8f8df61bc7274189122c123446248426",
+					"sha512": "881a853ee92d8cf513b07c164fea36b22a7305c256125bdfffdc5c65a4205c4c3fc2b5bcc98964349167ea68d40b8cd02551fcaa870a30d4601ba1caf6f63699"
+				}
+			}
+		}
+	},
+	"signatures": [
+		{
+			"keyid": "3b60e337a003f0465d881e34051b1350f0041b931bd68d95ce2066c81d36de1b",
+			"sig": "3046022100af26e7c415a1d724ace269d9498a83daadde0b55f155a4c95b431764bab85b7b02210091f5ae0acfe832cd71ba8249d784208ea265f7d103f6a0c92f75aeb939b9be33"
+		},
+		{
+			"keyid": "a89d235ee2f298d757438c7473b11b0b7b42ff1a45f1dfaac4c014183d6f8c45",
+			"sig": "3046022100af26e7c415a1d724ace269d9498a83daadde0b55f155a4c95b431764bab85b7b02210091f5ae0acfe832cd71ba8249d784208ea265f7d103f6a0c92f75aeb939b9be33"
+		}
+	]
+}

--- a/repository/staged/targets.json
+++ b/repository/staged/targets.json
@@ -3,7 +3,7 @@
 		"_type": "targets",
 		"spec_version": "1.0",
 		"version": 9,
-		"expires": "2024-09-12T06:53:10Z",
+		"expires": "2024-09-12T06:13:15Z",
 		"targets": {
 			"artifact.pub": {
 				"length": 177,
@@ -109,6 +109,34 @@
 					"sha512": "fdebade075c4840d40f1806a14d0660ae1d22f47c0516abc4141e09f4ddf6ee6f4dbfbf08a7025bea10a4b8794658a4cd8ebb1024b963f239a9bfe02c2057fc6"
 				}
 			}
+		},
+		"delegations": {
+			"keys": {
+				"3b60e337a003f0465d881e34051b1350f0041b931bd68d95ce2066c81d36de1b": {
+					"keytype": "ecdsa",
+					"scheme": "ecdsa-sha2-nistp256",
+					"keyid_hash_algorithms": [
+						"sha256",
+						"sha512"
+					],
+					"keyval": {
+						"public": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEoLrh0jmOfHWLwsyo/4oGbldF91WV\nfXvxVlDhW8fZwP/3vTnliBkDp5sH8/Dpm1SBOHkqENVt1+4Un/sFtl2zAQ==\n-----END PUBLIC KEY-----\n"
+					}
+				}
+			},
+			"roles": [
+				{
+					"name": "registry.npmjs.org",
+					"keyids": [
+						"3b60e337a003f0465d881e34051b1350f0041b931bd68d95ce2066c81d36de1b"
+					],
+					"threshold": 1,
+					"terminating": true,
+					"paths": [
+						"registry.npmjs.org/*"
+					]
+				}
+			]
 		}
 	},
 	"signatures": [

--- a/repository/staged/targets/registry.npmjs.org/keys.json
+++ b/repository/staged/targets/registry.npmjs.org/keys.json
@@ -1,0 +1,26 @@
+{
+    "keys": [
+        {
+            "keyId": "SHA256:jl3bwswu80PjjokCgh0o2w5c2U4LhQAE57gj9cz1kzA",
+            "keyUsage": "npm:signatures",
+            "publicKey": {
+                "rawBytes": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE1Olb3zMAFFxXKHiIkQO5cJ3Yhl5i6UPp+IhuteBJbuHcA5UogKo0EWtlWwW6KSaKoTNEYL7JlCQiVnkhBktUgg==",
+                "keyDetails": "PKIX_ECDSA_P256_SHA_256",
+                "validFor": {
+                    "start": "1999-01-01T00:00:00.000Z"
+                }
+            }
+        },
+        {
+            "keyId": "SHA256:jl3bwswu80PjjokCgh0o2w5c2U4LhQAE57gj9cz1kzA",
+            "keyUsage": "npm:attestations",
+            "publicKey": {
+                "rawBytes": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE1Olb3zMAFFxXKHiIkQO5cJ3Yhl5i6UPp+IhuteBJbuHcA5UogKo0EWtlWwW6KSaKoTNEYL7JlCQiVnkhBktUgg==",
+                "keyDetails": "PKIX_ECDSA_P256_SHA_256",
+                "validFor": {
+                    "start": "2022-12-01T00:00:00.000Z"
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
#### Summary
Added the npm delegation, versioned bumped and signed, no other changes.

Look for:
Version: 3
* Public key (PEM encoded) should be the same as in `1.registry.npmjs.json`
* File hash for delegated file `keys.json` should not have changed since previous version.
* KeyType should be `ecdsa` in `targets.json`

**Note** the signature of `registry.npm.json` contains signatures with both new and old key id (key id changed as the key type was updated), I added that because during test last week, the `verify` command did behave strange when only the new key id was there, it only verified correctly ~1/3 so it seems that the key ids are confused internally in the tool as they refer to the same key.


#### Release Note
N/A

#### Documentation
N/A
