### PR TITLE
Tweak git attributes to fix default diff behaviour

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,3 @@
-# These directories contain TUF and other assets that are either digested
-# or sized-checked so CRLF normalization breaks them.
-ceremony/** binary
-repository/** binary
+# Line endings for TUF metadata and targets should be normalised and consistent
+ceremony/**     text eol=lf
+repository/**   text eol=lf


### PR DESCRIPTION
PR #588 introduced a change to the gitattributes to prevent autocrlf from changing line endings of files which are digested or size checked (see issue

Telling git to treat all files in the TUF repository as binaries makes the default behaviour of `git diff` less useful. While it can be fixed by passing `--text`, we can instead modify our gitattributes to treat files in the TUF repository as LF line-endings only. This change will ensure files are committed with LF line endings and do not have the line-endings converted on checkout from the index.