### PR TITLE
Add migration material

### DIFF
--- a/docs/migration/README.md
+++ b/docs/migration/README.md
@@ -7,7 +7,7 @@ tuf-on-ci actions.
 
 ## Summary
 
-Roughly he migration steps are
+Roughly the migration steps are
 1. Prepare the GitHub project, workflows, cloud services and the data
    _without disrupting the current operations_
 2. Run the initial signing event with tuf-on-ci, do the necessary changes to metadata _without disrupting
@@ -22,6 +22,9 @@ The complication here is that starting step 2 (making a copy of the current meta
 the online signing machinery will modify metadata every three days. Within that time we need to either:
 * Decide the signing event was not successful and restart step 2 at a later date or
 * complete steps 2 and 3
+
+The deadline can be extended by a couple of days (as the actual expiry period is ~7 days) but this requires
+additional communication with on-call.
 
 ## Detailed playbook
 
@@ -66,7 +69,8 @@ This playbook and manuals for signers and maintainers.
 
 #### Signer orientation
 
-Make sure signers have installed and tested the software, and understand what will be requested during the signing event
+Make sure signers have installed and tested the software, and understand what will be requested during the signing
+event -- especially with regards ~3 day timeline to evaluate and make a go/no-go decision.
 
 #### General outreach
 

--- a/docs/migration/README.md
+++ b/docs/migration/README.md
@@ -1,0 +1,152 @@
+# Migration to tuf-on-ci managed TUF repository
+
+The plan is to manage root-signing with [tuf-on-ci](https://github.com/theupdateframework/tuf-on-ci),
+just like root-signing-staging. This is documented in https://github.com/sigstore/root-signing/issues/929:
+in short it aims to replace the current workflows and code with much smaller workflows that use the
+tuf-on-ci actions.
+
+## Summary
+
+Roughly he migration steps are
+1. Prepare the GitHub project, workflows, cloud services and the data
+   _without disrupting the current operations_
+2. Run the initial signing event with tuf-on-ci, do the necessary changes to metadata _without disrupting
+   the current operations_: this is achieved by
+   * modifying a separate copy of the metadata
+   * disabling the metadata publishing from tuf-on-ci
+3. If CI tests pass and manual testing looks good: disable current repository workflows, enable metadata
+   publishing from tuf-on-ci
+4. Remove now obsolete workflows, code and metadata copies
+
+The complication here is that starting step 2 (making a copy of the current metadata) starts a timer as
+the online signing machinery will modify metadata every three days. Within that time we need to either:
+* Decide the signing event was not successful and restart step 2 at a later date or
+* complete steps 2 and 3
+
+## Detailed playbook
+
+### 1. Preparation
+
+All of these steps can be taken without time pressure from the online signing process.
+
+#### Update GitHub project settings
+
+Review root-signing settings in sigstore/community, compare to root-signing-staging settings
+and https://github.com/theupdateframework/tuf-on-ci/blob/main/docs/REPOSITORY-MAINTENANCE.md:
+Enable things that are required by tuf-on-ci (do not disable the permissions required by legacy root-signing).
+
+Define GitHub variables and secrets:
+* Variable GCP_SERVICE_ACCOUNT (this is the online signing service account)
+* Variable GCP_WORKLOAD_IDENTITY_PROVIDER (this is the online signing identity provider)
+* Secret TUF_ON_CI_TOKEN (this is a sigstore-bot token)
+
+#### Update GCP configuration
+
+The settings should be easy to copy from root-signing-staging, with the exception that there are now two different
+service accounts: one for KMS and one for GCS
+* KMS: Online signing must be possible from the online-sign workflow from the main branch
+* GCS: uploading must be possible from publish workflow from the publish branch
+
+#### Update targets/ directory in git
+
+Currently targets/ does not quite match the repository contents.
+
+#### Add tuf-on-ci workflows to git
+
+Add the workflows but disable scheduled runs and specifically prevent publishing before it is enabled.
+
+#### Add import configuration to git
+
+* Add import script that copies metadata in expected locations and rewrites whitespace (so future diffs are manageable)
+* Add configuration file for the actual tuf-on-ci import
+
+#### Add/Update playbooks to git
+
+This playbook and manuals for signers and maintainers.
+
+#### Signer orientation
+
+Make sure signers have installed and tested the software, and understand what will be requested during the signing event
+
+#### General outreach
+
+Communicate the upcoming changes to Sigstore community
+
+### 2. Initial signing event
+
+The initial signing event can be restarted if it looks like there are issues that cannot be solved within the ~3 day timeline.
+It makes sense to start the signing event just after online signing to make that window as large as possible.
+
+#### Start signing event
+
+* Maintainer: Run the import script to copy current metadata to new directory, merge to main
+* Maintainer: run tuf-on-ci-import-repo with the prepared configuration file: this starts a signing event
+* Maintainer: run tuf-on-ci-delegate to modify online roles in the signing event:
+  * they should use the same key (this makes sense in root-signing as both snapshot and timestamp are
+    signed in same process with same access credentials)
+  * signing period is 4 days, expiry 7 days
+
+#### Signing event
+
+Every signer in the repository needs to sign the signing event at this point by running `tuf-on-ci-sign`:
+this is required because the keyids of all keys have changed (the actual key content has not).
+
+** TODO: This includes the npmjs signer: it is unclear how this signing happens at this point**
+
+In the same signing event PR all workflows can be enabled. Note that:
+* deploy-to-gcs step should be still left commented in publish workflow
+* the legacy workflows can keep running (although online-sign can be disabled if schedule is tight )
+
+#### First online sign
+
+Merging the signing event PR
+* triggers online signing
+* publishes the test "preprod" repository sigstore.github.io/root-signing/
+* runs all client tests against that repository
+* does NOT publish to production GCS yet as this is still disabled
+
+Manual client tests against this repository are now possible.
+
+
+### 3. Migration
+
+#### Disable publishing from legacy workflows
+
+Make sure that legacy publishing can no longer happen under any circumstances
+
+#### Publish to GCS
+
+* Enable GCS Publish by uncommenting lines in publish workflow
+* dispatch online-sign workflow manually to kickstart the process
+  (this will not actually sign as it's not needed but will trigger publishing)
+
+#### Update sigstore-prober
+
+The reusable prober tuf_preprod_repo input default value should be set to: "https://sigstore.github.io/root-signing"
+
+### 4. Post-migration
+
+#### Remove legacy workflows
+
+#### Update README
+
+* Remove references to obsolete processes
+* Update content so it links to the generated repository description
+
+#### Delete code and data that is no longer needed in git
+
+This is almost all directories in the repo (pkg, ceremony, release, config, cmd, scripts, repository) but this can happen piece by piece.
+
+#### Update GitHub project settings
+
+Disable any permissions that were enabled for the legacy workflows but are not needed by tuf-on-ci
+
+#### Remove non-versioned metadata from production GCS bucket
+
+The bucket currently contains URLs like /root.json which are not published by tuf-on-ci and not used by actual TUF clients.
+
+We should remove these files as obsolete (or alternatively add some code that keeps publishing them)
+
+#### Handle preprod bucket GCS
+
+tuf-on-ci uses Github Pages for the same purpose so preprod bucket no longer gets updated.

--- a/docs/migration/import-config.json
+++ b/docs/migration/import-config.json
@@ -1,0 +1,22 @@
+{
+  "root": {
+    "x-tuf-on-ci-signing-period": 31,
+    "x-tuf-on-ci-expiry-period": 182,
+    "1e1d65ce98b10addad4764febf7dda2d0436b3d3a3893579c0dddaea20e54849": "@santiagotorres",
+    "230e212616274a4195cdc28e9fce782c20e6c720f1a811b40f98228376bdd3ac": "@-replace-me-with-timestamp-key",
+    "3c344aa068fd4cc4e87dc50b612c02431fbc771e95003993683a2b0bf260cf0e": "@dlorenc",
+    "923bb39e60dd6fa2c31e6ea55473aa93b64dd4e53e16fbe42f6a207d3f97de2d": "gcpkms://projects/sigstore-root-signing/locations/global/keyRings/root/cryptoKeys/timestamp",
+    "e2f59acb9488519407e18cbfc9329510be03c04aca9929d2f0301343fec85523": "@bobcallaway",
+    "ec81669734e017996c5b85f3d02c3de1dd4637a152019fe1af125d2f9368b95e": "@mnm678",
+    "fdfa83a07b5a83589b87ded41f77f39d232ad91f7cce52868dacd06ba089849f": "@joshuagl"
+  },
+  "targets": {
+    "x-tuf-on-ci-expiry-period": 3650,
+    "x-tuf-on-ci-signing-period": 31,
+    "3b60e337a003f0465d881e34051b1350f0041b931bd68d95ce2066c81d36de1b": "@-npm-signer"
+  },
+  "registry.npmjs.org": {
+    "x-tuf-on-ci-expiry-period": 182,
+    "x-tuf-on-ci-signing-period": 31
+  }
+}

--- a/docs/migration/prep-import.py
+++ b/docs/migration/prep-import.py
@@ -1,0 +1,30 @@
+# This script is part of the tuf-on-ci migration
+#
+# It takes "legacy" root-signing metadata (from repository/repository), writes
+# copies in metadata/ in a format that is "compatible" with tuf-on-ci output.
+# (in other words, changes whitespace rules and filepaths)
+#
+# The actions here do not affect the "canonical representation" of the metadata
+# so to clients this metadata is the same as the legacy one.
+
+import os
+import shutil
+
+from tuf.api.metadata import Metadata
+from tuf.api.serialization.json import JSONSerializer
+
+os.makedirs("metadata/root_history", exist_ok=True)
+
+# Copy old root metadata as is: some of it is not considered valid by python-tuf
+version = 1
+while os.path.exists(f"repository/repository/{version}.root.json"):
+    shutil.copyfile(f"repository/repository/{version}.root.json", f"metadata/root_history/{version}.root.json")
+    version += 1
+
+# current metadata, convert to tuf-on-ci layout
+for rolename in ["root", "timestamp", "snapshot", "targets", "registry.npmjs.org"]:
+    md: Metadata = Metadata.from_file(f"repository/repository/{rolename}.json")
+    md.to_file(f"metadata/{rolename}.json", JSONSerializer())
+
+# For the current root we do want the version in root_history to match root.json bit by bit
+shutil.copyfile("metadata/root.json", f"metadata/root_history/{version - 1}.root.json")

--- a/playbooks/tuf-on-ci/MAINTAINER.md
+++ b/playbooks/tuf-on-ci/MAINTAINER.md
@@ -1,0 +1,91 @@
+# Maintainer manual for Sigstore root-signing
+
+## Setup
+
+Maintainers need push access to the upstream repository (as signing events are started by
+pushing `sign/*` branches). Follow the signer setup instructions except in your
+`.tuf-on-ci-sign.ini` set push-remote to the upstream repo as well:
+  ```
+  [settings]
+  user-name = @<YOUR-GITHUB-USER-NAME>
+  push-remote = upstream
+  pull-remote = upstream
+  ```
+
+## Metadata maintenance
+
+Metadata can be modified with two ways: Modifying delegations by running
+`tuf-on-ci-delegate` or by modifying the artifacts.
+* Comments should always be added in the signing event PR to keep signers aware of changes
+* Multiple changes can be done within a single signing event: These changes can modify different
+  roles and artifacts
+
+### Modifying delegations (signers, thresholds, etc)
+
+Signers, thresholds, expiry periods and online keys can be modified with the
+`tuf-on-ci-delegate <signing-event> <role>` command.
+* This will create a commit with the changes, pushes this to a branch on the upstream repo
+* GitHub will suggest to "Create a pull request by visiting URL" but this is not required:
+  a signing event PR is automatically opened by the signing-event workflow
+* The signing event argument must start with "sign/" but can be otherwise freely chosen:
+  It will be used as branch name.
+* The signing-event workflow will add a comment naming the signers who need to act:
+  Remember to document your changes in a signing event PR comment.
+
+#### Examples
+
+<details>
+  <summary>Remove a root signer and add another</summary>
+    Remove @jku and and add @a-new-signer as signer. The resulting signing event
+    will first request @a-new-signer to accept the invite, and then request all
+    signers to sign the change.
+
+    ```
+    $ tuf-on-ci-delegate sign/add-a-signer root
+    Remote branch not found: branching off from main
+    Signing event sign/add-a-signer (commit 0b0461f)
+    Modifying delegation for root
+
+    Configuring role root
+    1. Configure signers: [@jku, @kommendorkapten, @joshuagl, @mnm678], requiring 2 signatures
+    2. Configure expiry: Role expires in 91 days, re-signing starts 35 days before expiry
+    Please choose an option or press enter to continue: 1
+    Please enter list of root signers [@jku, @kommendorkapten, @joshuagl, @mnm678]: @a-new-signer, @kommendorkapten, @joshuagl, mnm678
+    Please enter root threshold [2]: 
+    1. Configure signers: [@a-new-signer, @kommendorkapten, @joshuagl, @mnm678], requiring 2 signatures
+    2. Configure expiry: Role expires in 91 days, re-signing starts 35 days before expiry
+    Please choose an option or press enter to continue: 
+    Confirm user presence for key ECDSA-SK SHA256:Ca1J+gvZjwnq4UGRyuRzwdJj9tpYtAiweSLtcRui5nA
+    User presence confirmed
+    Enumerating objects: 10, done.
+    Counting objects: 100% (10/10), done.
+    Delta compression using up to 8 threads
+    Compressing objects: 100% (6/6), done.
+    Writing objects: 100% (6/6), 725 bytes | 725.00 KiB/s, done.
+    Total 6 (delta 2), reused 0 (delta 0), pack-reused 0 (from 0)
+    remote: Resolving deltas: 100% (2/2), completed with 2 local objects.
+    remote: 
+    remote: Create a pull request for 'sign/add-a-signer' on GitHub by visiting:
+    remote:      https://github.com/jku/tuf-on-ci-sigstore-test/pull/new/sign/add-a-signer
+    remote: 
+    To ssh://github.com/jku/tuf-on-ci-sigstore-test.git
+    * [new branch]      HEAD -> sign/add-a-signer
+
+    ```
+</details>
+
+### Modifying artifacts (e.g. trusted_root.json)
+
+Artifact modifications can be done with plain git:
+* make a commit that modifies a file in `targets/`, push this change to a signing
+  event branch. Branch name must start with "sign/" but can be otherwise freely chosen
+* GitHub will suggest to "Create a pull request by visiting URL" but this is not required:
+  a signing event PR is automatically opened by the signing-event workflow. This PR
+  will include the required metadata changes
+* The signing-event workflow will add a comment naming the signers who need to act:
+  Remember to document your changes in a signing event PR comment
+
+If the legacy custom metadata needs to be modified, there is another manual step:
+* Once the signing-event workflow has made the targets metadata changes, you can pull the
+  branch, modify the custom metadata manually, and push a new commit into the branch
+* Again, keep the signers informed about the changes with a PR comment

--- a/playbooks/tuf-on-ci/SIGNER.md
+++ b/playbooks/tuf-on-ci/SIGNER.md
@@ -1,0 +1,58 @@
+# Signer manual for Sigstore root-signing
+
+## One-time setup for new signers
+
+### Yubikey configuration
+
+Generate a PIV Digital Signature key on your hardware key if you don't have one yet.
+
+Using [Yubikey Manager](https://www.yubico.com/support/download/yubikey-manager/)
+this is possible in _Applications -> PIV -> Configure certificates -> Digital signature_.
+Another option is `cosign piv-tool`.
+
+### Software install
+
+* Install tuf-on-ci-sign
+  ```
+  # this example uses a virtualenv: feel free to install tuf-on-ci-sign elsewhere
+  python3 -m venv ~/.venvs/tuf-on-ci-sign
+  source ~/.venvs/tuf-on-ci-sign/bin/activate
+  pip install tuf-on-ci-sign
+
+  # If you are on MacOS and the install fails, you can try
+  #   brew install swig
+  ```
+* Install Yubicos PKCS#11 module
+  * on Debian `sudo apt install ykcs11`
+  * on MacOS `brew install yubico-piv-tool`
+
+### Repository setup
+
+* Fork the repository on github: https://github.com/sigstore/root-signing/fork
+* clone your fork and add the upstream as a remote:
+  ```
+  git clone https://github.com/<YOUR-GITHUB-USER-NAME>/root-signing.git
+  cd root-signing
+  git remote add upstream https://github.com/sigstore/root-signing.git
+  ```
+* Create `.tuf-on-ci-sign.ini` with this content:
+  ```
+  [settings]
+  user-name = @<YOUR-GITHUB-USER-NAME>
+  push-remote = origin
+  pull-remote = upstream
+  ```
+
+## Signing
+
+When a signing event asks you to sign or to accept an invite:
+* Read the signing event PR comments to find out the purpose and content of this signing event
+* If the artifacts in `targets/` (such as `targets/trusted_root.json`) are modified, verify
+  that the proposed changes are sensible
+* Change into `root-signing` directory
+* Enter your virtualenv if you use one: `source ~/.venvs/tuf-on-ci-sign/bin/activate`
+* Run signing tool: `tuf-on-ci-sign <SIGNING-EVENT>`
+  * if you are accepting an invite, choose "Yubikey" as your key type
+  * if you are signing, review the changes
+  * Signing automatically commits the signature and pushes it to a branch on your fork
+* After signing, click the provided link to create a PR to the signing event branch


### PR DESCRIPTION
Add documentation and one time scripts for tuf-on-ci migration (#1247, see #929 for more context).
 * Add migration plan
 * Add playbooks for signers and maintainers
 * add a short import script and a config file for the initial signing event
 