### PR TITLE
client tests: Install a release version of sigstore-java

### DIFF
--- a/.github/workflows/custom-test.yml
+++ b/.github/workflows/custom-test.yml
@@ -153,10 +153,11 @@ jobs:
         with:
           repository: "sigstore/sigstore-java"
           fetch-tags: true
+          fetch-depth: 0
 
       - name: Build cli from latest release tag, unpack distribution
         run: |
-          git checkout $(git describe --tags --match="v[0-9]*" HEAD)
+          git checkout $(git describe --tags --match="v[0-9]*" --abbrev=0 HEAD)
           ./gradlew :sigstore-cli:build
           tar -xvf sigstore-cli/build/distributions/sigstore-cli-*.tar --strip-components 1
 


### PR DESCRIPTION
The sigstore-java installation is a bit of a hack (as the CLI we use is not part of any released binary package).

Fix the hack so that it actually builds the latest release tag (that is part of main branch).

---

* This is already in use in root-signing-staging
* Merging this should not affect the ongoing migration in any way