### PR TITLE
tuf-on-ci migration: Enable publishing to production

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,25 +43,23 @@ jobs:
       id-token: 'write' # for signing with the GitHub Actions workflow identity
     uses: ./.github/workflows/test.yml
 
-  # disabled during migration
-  # (when enabling remember to add to update-issue.needs)
-  #deploy-to-gcs:
-  #  needs: [test-deployed-pages]
-  #  permissions:
-  #    id-token: 'write' # for authenticating with OIDC
-  #  uses: ./.github/workflows/deploy-to-gcs.yml
+  deploy-to-gcs:
+    needs: [test-deployed-pages]
+    permissions:
+      id-token: 'write' # for authenticating with OIDC
+    uses: ./.github/workflows/deploy-to-gcs.yml
 
-  #test-deployed-gcs:
-  #  needs: [deploy-to-gcs]
-  #  if: always() && !failure() && !cancelled()
-  #  permissions:
-  #    issues: 'write' # for modifying Issues
-  #    id-token: 'write' # for signing with the GitHub Actions workflow identity
-  #  uses: ./.github/workflows/test-gcs.yml
+  test-deployed-gcs:
+    needs: [deploy-to-gcs]
+    if: always() && !failure() && !cancelled()
+    permissions:
+      issues: 'write' # for modifying Issues
+      id-token: 'write' # for signing with the GitHub Actions workflow identity
+    uses: ./.github/workflows/test-gcs.yml
 
   update-issue:
     runs-on: ubuntu-latest
-    needs: [build, deploy-to-pages, test-deployed-pages]
+    needs: [build, deploy-to-pages, test-deployed-pages, deploy-to-gcs, test-deployed-gcs]
     if: always() && !cancelled()
     permissions:
       issues: 'write' # for modifying Issues


### PR DESCRIPTION
Switch on the publishing to production GCS bucket (which was left off in the tuf-on-ci migration for some manual testing)
* The preprod tests (TUF smoke test, sigstore client tests) are green. This covers cosign, sigstore-go, sigstore-python, sigstore-java, sigstore-js
* We have manually tested a few clients, including cosign v2.2.0
* this will unfortunately break sigstore-rs temporarily (#1251)
* There is no rush but a bit of urgency: on-call starts getting alerts on Wednesday (because of timestamp that expires on 2024-09-06). 

Fixes #1340

Asking for reviews from at least @haydentherapper and @kommendorkapten