### PR TITLE
README rewrite proposal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+## Sigstore root-signing
+
 root-signing project maintains the TUF repository used to securely deliver the
 _Sigstore trust root (trusted_root.json)_ to Sigstore clients.
 
@@ -13,17 +15,17 @@ _Sigstore trust root (trusted_root.json)_ to Sigstore clients.
 
 The repository is published for sigstore client consumption at https://tuf-repo-cdn.sigstore.dev/.
 
-The metadata sources can be found in [metadata/] folder, artifacts (like trusted_root.json) in [targets/] folder.
-See [#Operation] for more details on how to modify these sources.
-
-All changes to artifacts or metadata require cryptographic signatures from Sigstore keyholders. Current
-keyholders, signature requirements and the signing schedule are documented in 
-[the published repository](https://tuf-repo-cdn.sigstore.dev/).
+The metadata sources can be found in [metadata/](metadata/) folder, artifacts (like trusted_root.json) in [targets/](targets/) folder.
+See [Operation](#operation) for more details on how to modify these sources.
 
 #### Keyholders
 
 root-signing security relies on keyholders: they should be trusted community members who are willing and able to
 perform keyholder duties like verifying new trusted_root.json content and signing in signing events.
+
+All changes to artifacts or metadata require cryptographic signatures from Sigstore keyholders. Current
+keyholders, signature requirements and the signing schedule are documented in
+[the published repository](https://tuf-repo-cdn.sigstore.dev/)
 
 | Keyholders | Term |
 | - | - |
@@ -34,8 +36,8 @@ perform keyholder duties like verifying new trusted_root.json content and signin
 | Santiago Torres-Arias | June 2021 - |
 
 | Emeritus keyholders | Term |
+| - | - |
 | Luke Hinds | June 2021 - July 2022 |
-
 
 ### Operation
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,23 @@ All changes to artifacts or metadata require cryptographic signatures from Sigst
 keyholders, signature requirements and the signing schedule are documented in 
 [the published repository](https://tuf-repo-cdn.sigstore.dev/).
 
+#### Keyholders
+
+root-signing security relies on keyholders: they should be trusted community members who are willing and able to
+perform keyholder duties like verifying new trusted_root.json content and signing in signing events.
+
+| Keyholders | Term |
+| - | - |
+| Joshua Lock | July 2022 -  |
+| Bob Callaway | June 2021 -  |
+| Dan Lorenc | June 2021 -  |
+| Marina Moore | June 2021 - |
+| Santiago Torres-Arias | June 2021 - |
+
+| Emeritus keyholders | Term |
+| Luke Hinds | June 2021 - July 2022 |
+
+
 ### Operation
 
 The TUF repository is modified in two ways:


### PR DESCRIPTION
This is a proposal for a new README structure: I am hoping for any feedback on the choices made here -- this is certainly not the only way to do this.

* Remove implementation details that are no longer relevant, link to current docs
* Remove the explicitly listed keyids and yubikey certs: I think these are just not that useful. If we want someone to verify the data without a TUF client, then they should really look at the actual public keys -- but would also need to read through the metadata to verify those keys are actually used. If we want to expose either keyids or public keys in "human readable" form, I suggest we add them to the repository status page https://tuf-repo-cdn.sigstore.dev/index.html so it gets automatically updated
* Remove list of artifacts: this was out of date already in the sense that it did not even trusted_root.json which is the main artifact. We can reintroduce this if it's useful but legacy artifacts should then be de-emphasized
* Replace ceremony overview with description of how root-signing now works

CC @sigstore/sigstore-keyholders 
