### PR TITLE
gitattributes: Set eol=lf for data directories

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
 # Line endings for TUF metadata and targets should be normalised and consistent
-ceremony/**     text eol=lf
-repository/**   text eol=lf
+metadata/**     text eol=lf
+targets/**      text eol=lf


### PR DESCRIPTION
For both metadata/ and targets/ we would like the line endings standardized -- this was already the case in previous directory structure, let's update gitattributes.

