### PR TITLE
Workflow updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,15 +14,6 @@
 
 version: 2
 updates:
-  - package-ecosystem: "gomod"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    groups:
-      gomod:
-        update-types:
-          - "patch"
-
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/custom-test.yml
+++ b/.github/workflows/custom-test.yml
@@ -75,6 +75,35 @@ jobs:
               --bundle bundle.json \
               artifact
 
+  cosign-old-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: sigstore/cosign-installer@4959ce089c160fddf62f7b42464195ba1a56d382 # v3.6.0
+        with:
+          cosign-release: "v2.2.0"
+
+      - name: Download initial root
+        run: curl -o root.json ${METADATA_URL}/5.root.json
+
+      - name: Test published repository with cosign 2.2
+        run: |
+          touch artifact
+
+          # initialize from the published repository
+          cosign initialize --root root.json --mirror ${METADATA_URL}
+
+          # sign, then verify using this workflows oidc identity
+          cosign sign-blob \
+              --yes \
+              --bundle bundle.json \
+              artifact
+
+          cosign verify-blob \
+              --certificate-identity $IDENTITY \
+              --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+              --bundle bundle.json \
+              artifact
+
   sigstore-go:
     runs-on: ubuntu-latest
     needs: [sigstore-python]

--- a/.github/workflows/signing-event.yml
+++ b/.github/workflows/signing-event.yml
@@ -19,6 +19,7 @@ jobs:
 
     steps:
       - name: Signing event
+        if: github.repository_owner == 'sigstore' # avoid running in forks
         uses: theupdateframework/tuf-on-ci/actions/signing-event@27c49c016591c7cfea57f6b15296f714a5c4a5f6 # v0.13.0
         with:
           token: ${{ secrets.TUF_ON_CI_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-gcs.yml
+++ b/.github/workflows/test-gcs.yml
@@ -21,8 +21,9 @@ jobs:
         uses: theupdateframework/tuf-on-ci/actions/test-repository@27c49c016591c7cfea57f6b15296f714a5c4a5f6 # v0.13.0
         with:
           metadata_url: https://tuf-repo-cdn.sigstore.dev/
-          valid_days: 3
-          offline_valid_days: 30
+          # when workflow is reused in publish.yml, do not require future validity
+          valid_days: ${{ github.event_name == 'workflow_call' && 0 || 3 }}
+          offline_valid_days: ${{ github.event_name == 'workflow_call' && 0 || 30 }}
 
   custom-smoke-test:
     permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,8 +22,9 @@ jobs:
         with:
           metadata_url: https://sigstore.github.io/root-signing/
           update_base_url: https://tuf-repo-cdn.sigstore.dev/
-          valid_days: 3
-          offline_valid_days: 30
+          # when workflow is reused in publish.yml, do not require future validity
+          valid_days: ${{ github.event_name == 'workflow_call' && 0 || 3 }}
+          offline_valid_days: ${{ github.event_name == 'workflow_call' && 0 || 30 }}
 
   custom-smoke-test:
     permissions:


### PR DESCRIPTION
This contains four separate workflow changes that I can put in separate PRs if requested to. These are all workflow related changes that have been tested in root-signing-staging:

* Do not always require future validity in test: this allows repository to get published even when signing event is for some reason not proceeding as quickly as expected
* Prevent signing-event from running in forks
* Add client test for older cosign
* remove golang from dependabot config

Fixes #1376 
