### PR TITLE
Add new keys for npmjs delegated target

### DIFF
--- a/targets/registry.npmjs.org/keys.json
+++ b/targets/registry.npmjs.org/keys.json
@@ -7,7 +7,8 @@
                 "rawBytes": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE1Olb3zMAFFxXKHiIkQO5cJ3Yhl5i6UPp+IhuteBJbuHcA5UogKo0EWtlWwW6KSaKoTNEYL7JlCQiVnkhBktUgg==",
                 "keyDetails": "PKIX_ECDSA_P256_SHA_256",
                 "validFor": {
-                    "start": "1999-01-01T00:00:00.000Z"
+                    "start": "1999-01-01T00:00:00.000Z",
+                    "end": "2025-01-29T00:00:00.000Z"
                 }
             }
         },
@@ -18,7 +19,30 @@
                 "rawBytes": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE1Olb3zMAFFxXKHiIkQO5cJ3Yhl5i6UPp+IhuteBJbuHcA5UogKo0EWtlWwW6KSaKoTNEYL7JlCQiVnkhBktUgg==",
                 "keyDetails": "PKIX_ECDSA_P256_SHA_256",
                 "validFor": {
-                    "start": "2022-12-01T00:00:00.000Z"
+                    "start": "2022-12-01T00:00:00.000Z",
+                    "end": "2025-01-29T00:00:00.000Z"
+                }
+            }
+        },
+        {
+            "keyId": "SHA256:DhQ8wR5APBvFHLF/+Tc+AYvPOdTpcIDqOhxsBHRwC7U",
+            "keyUsage": "npm:signatures",
+            "publicKey": {
+                "rawBytes": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEY6Ya7W++7aUPzvMTrezH6Ycx3c+HOKYCcNGybJZSCJq/fd7Qa8uuAKtdIkUQtQiEKERhAmE5lMMJhP8OkDOa2g==",
+                "keyDetails": "PKIX_ECDSA_P256_SHA_256",
+                "validFor": {
+                    "start": "2025-01-13T00:00:00.000Z"
+                }
+            }
+        },
+        {
+            "keyId": "SHA256:DhQ8wR5APBvFHLF/+Tc+AYvPOdTpcIDqOhxsBHRwC7U",
+            "keyUsage": "npm:attestations",
+            "publicKey": {
+                "rawBytes": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEY6Ya7W++7aUPzvMTrezH6Ycx3c+HOKYCcNGybJZSCJq/fd7Qa8uuAKtdIkUQtQiEKERhAmE5lMMJhP8OkDOa2g==",
+                "keyDetails": "PKIX_ECDSA_P256_SHA_256",
+                "validFor": {
+                    "start": "2025-01-13T00:00:00.000Z"
                 }
             }
         }


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Adds new keys to the npmjs delegated target in support of the forthcoming key rotation being done for the npm package registry:

* Adds new keys for `npm:signatures` and `npm:attestations` (same key used for both cases) which is valid starting on `2025-01-13T00:00:00.000Z`
* Adds an end date for the existing keys of `2025-01-29T00:00:00.000Z`