### PR TITLE
workflows: Fix valid days check

### DIFF
--- a/.github/workflows/test-gcs.yml
+++ b/.github/workflows/test-gcs.yml
@@ -25,8 +25,8 @@ jobs:
         with:
           metadata_url: https://tuf-repo-cdn.sigstore.dev/
           # when workflow is reused in publish.yml, do not require future validity
-          valid_days: ${{ github.event_name == 'workflow_call' && 0 || 3 }}
-          offline_valid_days: ${{ github.event_name == 'workflow_call' && 0 || 30 }}
+          valid_days: ${{ github.workflow == 'root-signing GCS repository tests' && 3 || 0 }}
+          offline_valid_days: ${{ github.workflow == 'root-signing GCS repository tests' && 30 || 0 }}
 
   custom-smoke-test:
     permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,8 +25,8 @@ jobs:
           metadata_url: https://sigstore.github.io/root-signing/
           update_base_url: https://tuf-repo-cdn.sigstore.dev/
           # when workflow is reused in publish.yml, do not require future validity
-          valid_days: ${{ github.event_name == 'workflow_call' && 0 || 3 }}
-          offline_valid_days: ${{ github.event_name == 'workflow_call' && 0 || 30 }}
+          valid_days: ${{ github.workflow == 'TUF-on-CI repository tests' && 3 || 0 }}
+          offline_valid_days: ${{ github.workflow == 'TUF-on-CI repository tests' && 30 || 0 }}
 
   custom-smoke-test:
     permissions:


### PR DESCRIPTION
This is actually never true:
    github.event_name == 'workflow_call'
as the event name in workflow_called workflows is the calling workflows event name.

Use the workflow name to distinguish the cases:
 * schedule: name is the test workflow name, use future validity checks
 * workflow_dispatch: name is the test workflow name, use future validity checks
 * workflow_call from publish.yml: name is calling workflown name, do not use future validity checks

Using workflow name for this is a bit of a hack and we should consider adding an input variable for this: that is a bigger change and should be tested well though.

See #1416.