### PR TITLE
workflows: Don't lint twice in signing events

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,6 +17,7 @@ name: Lint
 
 on:
   push:
+    branches: [main]
   pull_request:
 
 jobs:


### PR DESCRIPTION
Only lint on pushes to main branch to avoid duplicate lints in PRs like signing events that have a branch on origin.

We could maybe also avoid linting when workflows do not change (as currently only workflows are linted) but that's not included here