### PR TITLE
tests: Add sigstore-rs client test

### DIFF
--- a/.github/workflows/custom-test.yml
+++ b/.github/workflows/custom-test.yml
@@ -216,10 +216,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: [sigstore-python]
     steps:
+      # checkout branch of sigstore-rs with root v12 embedded
+      # TODO: Just use a released sigstore-rs when possible
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          repository: "sigstore/sigstore-rs"
-          ref: "7769a0c81d53b0174d4e1558108844be439705a4"
+          repository: "jku/sigstore-rs"
+          ref: "15400a3456163433a5aba1e10918324471c73f25"
           persist-credentials: false
 
       - name: tweak sigstore-rs to use the published TUF repository

--- a/.github/workflows/custom-test.yml
+++ b/.github/workflows/custom-test.yml
@@ -211,3 +211,35 @@ jobs:
               --certificate-identity $IDENTITY \
               --certificate-oidc-issuer https://token.actions.githubusercontent.com \
               artifact
+
+  sigstore-rs:
+    runs-on: ubuntu-latest
+    needs: [sigstore-python]
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: "sigstore/sigstore-rs"
+          ref: "7769a0c81d53b0174d4e1558108844be439705a4"
+          persist-credentials: false
+
+      - name: tweak sigstore-rs to use the published TUF repository
+        run: |
+          sed -ie "s#https://tuf-repo-cdn\.sigstore\.dev#$METADATA_URL#" src/trust/sigstore/constants.rs
+
+      - uses: Swatinem/rust-cache@f0deed1e0edfc6a9be95417288c0e1099b1eeec3
+      - name: Build
+        run: cargo build --example bundle
+
+      - name: Download bundle to verify
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          name: bundle
+
+      - name: Test published repository with sigstore-rs
+        run: |
+          touch artifact
+
+          cargo run --example bundle verify \
+              --identity $IDENTITY \
+              --issuer https://token.actions.githubusercontent.com \
+              artifact


### PR DESCRIPTION
* This test is not in root-signing-staging since the client does not support staging
* Uses current main HEAD since last release does not have the "bundle" example we use
* Does not test signing since the client does not support signing with the GitHub Actions workflow identity

Testing this is an issue:
* as mentioned, we can't test this in staging 
* Here the test currently fails because of #1431: sigstore-rs expects specifically computed TUF keyids which current root metadata does not provide. 
* we can do a signing event to fix the keyid but can only test the result after the signing event is merged (but not necessarily published to production)

Setting as draft for now: let's figure out what we do with 1431.