### PR TITLE
tests: Require metadata to be valid for 5 days

### DIFF
--- a/.github/workflows/test-gcs.yml
+++ b/.github/workflows/test-gcs.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           metadata_url: https://tuf-repo-cdn.sigstore.dev/
           # when workflow is reused in publish.yml, do not require future validity
-          valid_days: ${{ github.workflow == 'root-signing GCS repository tests' && 3 || 0 }}
+          valid_days: ${{ github.workflow == 'root-signing GCS repository tests' && 5 || 0 }}
           offline_valid_days: ${{ github.workflow == 'root-signing GCS repository tests' && 30 || 0 }}
 
   custom-smoke-test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
           metadata_url: https://sigstore.github.io/root-signing/
           update_base_url: https://tuf-repo-cdn.sigstore.dev/
           # when workflow is reused in publish.yml, do not require future validity
-          valid_days: ${{ github.workflow == 'TUF-on-CI repository tests' && 3 || 0 }}
+          valid_days: ${{ github.workflow == 'TUF-on-CI repository tests' && 5 || 0 }}
           offline_valid_days: ${{ github.workflow == 'TUF-on-CI repository tests' && 30 || 0 }}
 
   custom-smoke-test:


### PR DESCRIPTION
We are now signing timestamp 6 days before expiry (meaning every day). This means we can now require metadata to be valid for 5 days in the tests.

The change gives us more time to react to online signing issues.

Change has been tested in staging:
https://github.com/sigstore/root-signing-staging/pull/222

Fixes #1415