### PR TITLE
docs: Update failure.md

### DIFF
--- a/.github/TUF_ON_CI_TEMPLATE/failure.md
+++ b/.github/TUF_ON_CI_TEMPLATE/failure.md
@@ -1,1 +1,5 @@
 CC @sigstore/tuf-root-signing-codeowners, please have a look.
+
+* The workflow will be automatically retried every six hours: this issue will be updated based on retry results
+* If the failure looks like flaky infrastructure, it can be manually re-run. The workflows can also be dispatched manually (recommendation is to avoid dispatching `publish` workflow: dispatch `online-sign` instead and let that workflow dispatch `publish`)
+* Failures in `publish` or `online-sign` may be urgent: see expiry dates of current repository in https://tuf-repo-cdn.sigstore.dev/


### PR DESCRIPTION
Add some basic advice to the issue template. This content gets added to the issues that tuf-on-ci opens for these workflows: online-sign, publish, test, test-gcs and create-signing-events.

It's a little annoying to add info about `online-sign` and `publish` to all other failures too but I think it's worth it since those two are the ones we care most about.