### PR TITLE
tests: Pin sigstore-python for now

### DIFF
--- a/.github/workflows/custom-test.yml
+++ b/.github/workflows/custom-test.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Install sigstore-python, tweak it to use the published TUF repository
         run: |
-          pip install sigstore
+          pip install sigstore==3.6.5
 
           # tweak sigstore sources to use our publish URL
           # TODO: remove this once sigstore-python supports "--tuf-url" or similar


### PR DESCRIPTION
This is a temporary fix to stop tests from failing until there is an actual solution for https://github.com/sigstore/root-signing/issues/1542

I'll trigger the tests manually -- that closes the automatically opened issues for now but they will be reopened until this is merged.

---

#1542 should be left open so I remember to make real fix next week.