### PR TITLE
Dependabot: Use cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
     groups:
       actions:
         update-types:
@@ -27,6 +29,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
     groups:
       actions:
         update-types:


### PR DESCRIPTION
Use a 7 day cooldown for both actions and python dependencies (meaning yamllint).

This should be a best practice in any case but as an added bonus we can leave root-signing-staging *without* a cooldown: this should give us a week to notice issues in staging before things break here.