### PR TITLE
Add fixed ruby test

### DIFF
--- a/.github/workflows/custom-test.yml
+++ b/.github/workflows/custom-test.yml
@@ -230,7 +230,7 @@ jobs:
       - name: Download and configure initial root
         run: |
           curl -o root.json ${METADATA_URL}/1.root.json
-          METADATA_DIR=$(mktemp -d -t sigstore)
+          METADATA_DIR=$(mktemp -d -t root-signing-ruby-test.XXXXXX)
           sigstore-cli tuf init root.json --metadata-dir=${METADATA_DIR}
           sigstore-cli tuf refresh --metadata-dir=${METADATA_DIR} --metadata-url=${METADATA_URL}
 

--- a/.github/workflows/custom-test.yml
+++ b/.github/workflows/custom-test.yml
@@ -229,7 +229,7 @@ jobs:
 
       - name: Download and configure initial root
         run: |
-          curl -o root.json ${METADATA_URL}/1.root.json
+          curl -o root.json ${METADATA_URL}/5.root.json
           METADATA_DIR=$(mktemp -d -t root-signing-ruby-test.XXXXXX)
           sigstore-cli tuf init root.json --metadata-dir=${METADATA_DIR}
           sigstore-cli tuf refresh --metadata-dir=${METADATA_DIR} --metadata-url=${METADATA_URL}

--- a/.github/workflows/custom-test.yml
+++ b/.github/workflows/custom-test.yml
@@ -214,3 +214,37 @@ jobs:
               --certificate-identity $IDENTITY \
               --certificate-oidc-issuer https://token.actions.githubusercontent.com \
               artifact
+
+  sigstore-ruby:
+    runs-on: ubuntu-latest
+    needs: [sigstore-python]
+    steps:
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@8aeb6ff8030dd539317f8e1769a044873b56ea71 # v1.268.0
+        with:
+          ruby-version: 3.2
+
+      - name: Install sigstore-ruby
+        run: gem install sigstore-cli
+
+      - name: Download and configure initial root
+        run: |
+          curl -o root.json ${METADATA_URL}/1.root.json
+          METADATA_DIR=$(mktemp -d -t sigstore)
+          sigstore-cli tuf init root.json --metadata-dir=${METADATA_DIR}
+          sigstore-cli tuf refresh --metadata-dir=${METADATA_DIR} --metadata-url=${METADATA_URL}
+
+      - name: Download bundle to verify
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        with:
+          name: bundle
+
+      - name: Test published repository with sigstore-ruby
+        run: |
+          touch artifact
+
+          sigstore-cli verify \
+              --bundle=artifact-rekor1.sigstore.json \
+              --certificate-identity=$IDENTITY \
+              --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+              artifact


### PR DESCRIPTION
This is attempt 2 of #1571
* original was reverted since there were two small issues: see the added commits for details
* I tried testing this first in staging but that turns out not to be possible since sigstore-ruby does not seem to fully use trusted root from TUF: it hardcodes some public key material so does not work with root-signing-staging
* I've run this test on my fork: https://github.com/jku/root-signing/actions/runs/20267358200
