### PR TITLE
Create second signing config with Rekor v2 URL

### DIFF
--- a/targets/signing_config_rekor_v2.v0.2.json
+++ b/targets/signing_config_rekor_v2.v0.2.json
@@ -1,0 +1,57 @@
+{
+  "mediaType": "application/vnd.dev.sigstore.signingconfig.v0.2+json",
+  "caUrls": [
+    {
+      "url": "https://fulcio.sigstore.dev",
+      "majorApiVersion": 1,
+      "validFor": {
+        "start": "2022-04-13T20:06:15.000Z"
+      },
+      "operator": "sigstore.dev"
+    }
+  ],
+  "oidcUrls": [
+    {
+      "url": "https://oauth2.sigstore.dev/auth",
+      "majorApiVersion": 1,
+      "validFor": {
+        "start": "2022-04-13T20:06:15.000Z"
+      },
+      "operator": "sigstore.dev"
+    }
+  ],
+  "rekorTlogUrls": [
+    {
+      "url": "https://log2025-1.rekor.sigstore.dev",
+      "majorApiVersion": 2,
+      "validFor": {
+        "start": "2026-01-01T00:00:00Z"
+      },
+      "operator": "sigstore.dev"
+    },
+    {
+      "url": "https://rekor.sigstore.dev",
+      "majorApiVersion": 1,
+      "validFor": {
+        "start": "2021-01-12T11:53:27.000Z"
+      },
+      "operator": "sigstore.dev"
+    }
+  ],
+  "tsaUrls": [
+    {
+      "url": "https://timestamp.sigstore.dev/api/v1/timestamp",
+      "majorApiVersion": 1,
+      "validFor": {
+        "start": "2025-07-04T00:00:00Z"
+      },
+      "operator": "sigstore.dev"
+    }
+  ],
+  "rekorTlogConfig": {
+    "selector": "ANY"
+  },
+  "tsaConfig": {
+    "selector": "ANY"
+  }
+}


### PR DESCRIPTION
Signers may opt into using this signing config to default to writing to Rekor v2 rather than v1. This is useful for any clients that have high QPS requirements. Note that by opting into this configuration, the signer must acknowledge that verifiers who will ingest signatures recorded to Rekor v2 are on the latest SDK versions that support Rekor v2 entry formats.

We strongly recommend that signers use this signing config rather than hardcode the current Rekor v2 URL, so that the infrastructure maintainers can still create new log shards.

This signing configuration should be a superset of signing_config.v0.2.json, with the only addition being Rekor v2 URLs.

Signed-off-by: Hayden <8418760+Hayden-IO@users.noreply.github.com>