### PR TITLE
workflows: Switch publishing service account

### DIFF
--- a/.github/workflows/deploy-to-gcs.yml
+++ b/.github/workflows/deploy-to-gcs.yml
@@ -2,6 +2,13 @@ name: Deploy repository to GCS
 
 on:
   workflow_call:
+    inputs:
+      gcp_workload_identity_provider:
+        required: true
+        type: string
+      gcp_service_account:
+        required: true
+        type: string
 
 permissions: {}
 
@@ -22,12 +29,11 @@ jobs:
           mkdir repository
           tar --directory repository -xvf artifact.tar
 
-      # NOTE: This gcloud project/account is NOT the tuf-on-ci online signing account
       - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           token_format: access_token
-          workload_identity_provider: projects/306323169285/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider
-          service_account: tuf-gha@project-rekor.iam.gserviceaccount.com
+          workload_identity_provider: ${{ inputs.gcp_workload_identity_provider }}
+          service_account: ${{ inputs.gcp_service_account }}
 
       - uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,6 +48,9 @@ jobs:
     permissions:
       id-token: 'write' # for authenticating with OIDC
     uses: ./.github/workflows/deploy-to-gcs.yml
+    with:
+      gcp_workload_identity_provider: 'projects/306323169285/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider'
+      gcp_service_account: 'tuf-publisher@project-rekor.iam.gserviceaccount.com'
 
   test-deployed-gcs:
     needs: [deploy-to-gcs]


### PR DESCRIPTION
* Switch "tuf-gha" service account to "tuf-publisher": the new one is limited to the workflow and branch
* Also include a small refactor to make the root-signing and root-signing-staging workflows more identical: deploy-to-gcs now takes arguments

This depends on https://github.com/sigstore/public-good-instance/pull/3741