### PR TITLE
workflows: Add sigstore-rust to test set

### DIFF
--- a/.github/workflows/custom-test.yml
+++ b/.github/workflows/custom-test.yml
@@ -248,3 +248,43 @@ jobs:
               --certificate-identity=$IDENTITY \
               --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
               artifact
+
+  sigstore-rust:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          repository: "sigstore/sigstore-rust"
+          fetch-tags: true
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Checkout latest release tag
+        run: |
+          # examples are not available on crates.io: use git checkout
+          git checkout $(git describe --tags --match="sigstore-verify-v[0-9]*" --abbrev=0 HEAD)
+
+      - name: Install Rust toolchain
+        run: rustup toolchain install
+
+      - name: Download initial root
+        run: curl -o root.json ${METADATA_URL}/1.root.json
+
+      - name: Build required examples
+        run: |
+          cargo build -p sigstore-trust-root --example trust-instance -p sigstore-sign --example sign_blob -p sigstore-verify --example verify_bundle
+
+      - name: Trust the Sigstore instance
+        run: |
+          ./target/debug/examples/trust-instance --instance ${METADATA_URL} root.json
+
+      - name: Test published repository (sign and verify)
+        run: |
+          touch artifact
+          ./target/debug/examples/sign_blob --instance ${METADATA_URL} -o artifact.sigstore.json artifact
+          ./target/debug/examples/verify_bundle \
+              --instance ${METADATA_URL} \
+              --certificate-identity $IDENTITY \
+              --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+              artifact \
+              artifact.sigstore.json

--- a/.github/workflows/custom-test.yml
+++ b/.github/workflows/custom-test.yml
@@ -268,7 +268,7 @@ jobs:
         run: rustup toolchain install
 
       - name: Download initial root
-        run: curl -o root.json ${METADATA_URL}/1.root.json
+        run: curl -o root.json ${METADATA_URL}/5.root.json
 
       - name: Build required examples
         run: |

--- a/.github/workflows/custom-test.yml
+++ b/.github/workflows/custom-test.yml
@@ -250,6 +250,8 @@ jobs:
               artifact
 
   sigstore-rust:
+    permissions:
+      id-token: 'write' # For signing with the GitHub workflow identity
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3


### PR DESCRIPTION
* This uses git clone to get latest version: This is not ideal but we want to use sigstore-rust examples and those are not available from crates.io -- this is the same solution that sigstore-java test uses
* Same change is running in staging already, looks fine there. I also ran this in my fork.
